### PR TITLE
Aggresively cleanup intermediate files in non-dev environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
+# v0.11.0 (2020-02-21)
+
+- Configure the app so that when it runs in production it runs reproducibly by
+  cleaning up its intermediate files aggressively.
+
 # v0.10.0 (2020-02-20)
 
 - Move nginx config, Dockerfile & docker-compose.yml to top level.
 - Install dependencies from environment-lock.yml
 - Move `run_task.sh` and `cleanup.sh` to `scripts/` dir.
 - README updates.
-- Make layer and layer group visbility configurable. 
+- Make layer and layer group visbility configurable.
 - Make layer group expand/collapse state configurable.
   - HACK: If the first layer in the legend is in a collapsed layer group, QGIS
     will automatically expand the layer group. Set coastlines layer to be first

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - /share/appdata/qgreenland/QGreenland:/luigi/data:rw
       - ./qgreenland:/luigi/tasks/qgreenland:ro
     environment:
+      - ENVIRONMENT
       - EARTHDATA_USERNAME
       - EARTHDATA_PASSWORD
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./luigi/conf:/etc/luigi:ro
       - ./luigi/state:/luigi/state:rw
-      - /share/appdata/qgreenland/QGreenland:/luigi/data:rw
+      - /share/appdata/qgreenland:/luigi/data:rw
       - ./qgreenland:/luigi/tasks/qgreenland:ro
     environment:
       - ENVIRONMENT
@@ -26,7 +26,7 @@ services:
   webserver:
     image: nginx
     volumes:
-      - /share/appdata/qgreenland/QGreenland/release/:/usr/share/nginx/html/:ro
+      - /share/appdata/qgreenland/release/:/usr/share/nginx/html/:ro
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
       - 80:80

--- a/qgreenland/__init__.py
+++ b/qgreenland/__init__.py
@@ -3,4 +3,4 @@ import os
 PACKAGE_DIR = os.path.dirname(__file__)
 
 # TODO: bumpversion integration
-__version__ = 'v0.11.0dev'
+__version__ = 'v0.11.0'

--- a/qgreenland/__init__.py
+++ b/qgreenland/__init__.py
@@ -3,4 +3,4 @@ import os
 PACKAGE_DIR = os.path.dirname(__file__)
 
 # TODO: bumpversion integration
-__version__ = 'v0.10.0dev'
+__version__ = 'v0.11.0dev'

--- a/qgreenland/constants.py
+++ b/qgreenland/constants.py
@@ -9,7 +9,10 @@ ENVIRONMENT = os.environ.get('ENVIRONMENT', 'dev')
 
 DATA_DIR = '/luigi/data'
 WIP_DIR = f'{DATA_DIR}/luigi-wip'
-DATA_RELEASE_DIR = f'{DATA_DIR}/release/{__version__}'
+if 'dev' in __version__:
+    DATA_RELEASE_DIR = f'{DATA_DIR}/release/dev/{__version__}'
+else:
+    DATA_RELEASE_DIR = f'{DATA_DIR}/release/{__version__}'
 
 # Output target file of the task just before the ZipQGreenland task.
 # Presence indicates the project is ready to be zipped for release.

--- a/qgreenland/constants.py
+++ b/qgreenland/constants.py
@@ -2,6 +2,9 @@ import os
 from enum import Enum
 
 PROJECT = 'qgreenland'
+
+ENVIRONMENT = os.environ.get(ENVIRONMENT, 'dev')
+
 DATA_DIR = '/luigi/data'
 DATA_FINAL_DIR = f'{DATA_DIR}/{PROJECT}'
 DATA_RELEASE_DIR = f'{DATA_DIR}/release'

--- a/qgreenland/tasks/main.py
+++ b/qgreenland/tasks/main.py
@@ -10,6 +10,7 @@ from qgreenland.constants import (DATA_RELEASE_DIR,
                                   TaskType,
                                   ZIP_TRIGGERFILE)
 from qgreenland.tasks.layers import ArcticDEM, BedMachineDataset, Coastlines
+from qgreenland.util.misc import cleanup_intermediate_dirs
 from qgreenland.util.qgis import make_qgs
 
 
@@ -70,3 +71,6 @@ class ZipQGreenland(luigi.Task):
         os.rename(f'{tmp_name}.zip', self.output().path)
 
         os.remove(self.input().path)
+
+        if ENVIRONMENT != 'dev':
+            cleanup_intermediate_dirs(delete_fetch_dir=True)

--- a/qgreenland/tasks/main.py
+++ b/qgreenland/tasks/main.py
@@ -4,7 +4,8 @@ import shutil
 import luigi
 
 from qgreenland import PACKAGE_DIR, __version__
-from qgreenland.constants import (DATA_FINAL_DIR,
+from qgreenland.constants import (ENVIRONMENT,
+                                  DATA_FINAL_DIR,
                                   DATA_RELEASE_DIR,
                                   TMP_DIR,
                                   ZIP_TRIGGERFILE)
@@ -67,3 +68,6 @@ class ZipQGreenland(luigi.Task):
         os.rename(f'{tmp_name}.zip', self.output().path)
 
         os.remove(self.input().path)
+
+        if ENVIRONMENT != 'dev':
+

--- a/qgreenland/util/misc.py
+++ b/qgreenland/util/misc.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import time
 from contextlib import contextmanager
 
 import yaml
@@ -31,8 +32,23 @@ def temporary_path_dir(target):
     return
 
 
-def _rmtree(directory):
+def _rmtree(directory, *, retries=3):
+    """A more robust version of rmtree.
+
+    Retries in case of intermittent issues, e.g. with network storage.
+    """
     if os.path.isdir(directory):
+        for i in range(retries):
+            try:
+                shutil.rmtree(directory)
+                return
+            except OSError as e:
+                print(f'WARNING: shutil.rmtee failed for path: {directory}')
+                print(f'Exception: {e}')
+                print(f'Retrying in {i} seconds...')
+                time.sleep(i)
+
+        # Allow caller to receive exceptions raised on the final try
         shutil.rmtree(directory)
 
 

--- a/qgreenland/util/misc.py
+++ b/qgreenland/util/misc.py
@@ -32,6 +32,11 @@ def temporary_path_dir(target):
     return
 
 
+def cleanup_intermediate_dirs(delete_fetch_dir=False):
+    shutil.rmtree(WIP_DIR)
+
+
+
 def cleanup_output_dirs(delete_fetch_dir=False):
     """Delete output dirs.
 

--- a/qgreenland/util/misc.py
+++ b/qgreenland/util/misc.py
@@ -33,7 +33,7 @@ def temporary_path_dir(target):
 
 
 def _rmtree(directory, *, retries=3):
-    """A more robust version of rmtree.
+    """Add robustness to shutil.rmtree.
 
     Retries in case of intermittent issues, e.g. with network storage.
     """

--- a/qgreenland/util/qgis.py
+++ b/qgreenland/util/qgis.py
@@ -177,10 +177,6 @@ def make_qgs(path):
 
     _add_decorations(project)
 
-    # Set group options after adding the layers. Adding layers to a layer group
-    # mutates the layer group state (e.g., if the group is collapsed and a layer
-    # is added to it, it causes the group to be expanded.
-    # TODO: is this really true?
     _set_groups_options(project)
 
     _fix_layer_order(project)

--- a/qgreenland/util/qgis.py
+++ b/qgreenland/util/qgis.py
@@ -184,6 +184,10 @@ def make_qgs(path):
     # TODO: is it normal to write multiple times?
     project.write()
 
+    # Release all file locks! If we don't do this, we won't be able to clean up
+    # layer source files after zipping the project.
+    project.clear()
+
 
 def _fix_layer_order(project):
     """HACK. QGIS automatically selects and expands the first layer in the legend.


### PR DESCRIPTION
We can worry about performance in the future. For now, we want to be sure that our releases don't interfere with each other, so we set up the workflow to be environment-gnostic and do cleanup in non-dev environments. Devs are capable of cleaning up after themselves as-necessary with the cleanup script. Also for the future, we could make that cleanup script smarter/take arguments.