### PR TITLE
Utm zones

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.25.0
+current_version = 0.26.0dev
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<release>.*)?
 serialize = 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.26.0 (Unreleased)
+
+- New Miscellaneous layer: Universal Transverse Mercatur (UTM) Zones
+
 # v0.25.0 (2020-08-06)
 
 - Replace `ArcticDEM` layer task with generic `Raster` task.

--- a/qgreenland/__init__.py
+++ b/qgreenland/__init__.py
@@ -1,1 +1,1 @@
-__version__ = 'v0.25.0'
+__version__ = 'v0.26.0dev'

--- a/qgreenland/assets/styles/transparent_shape.qml
+++ b/qgreenland/assets/styles/transparent_shape.qml
@@ -1,0 +1,34 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.14.0-Pi" styleCategories="Symbology">
+  <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
+    <symbols>
+      <symbol force_rhr="0" type="fill" name="0" alpha="1" clip_to_extent="1">
+        <layer class="SimpleFill" locked="0" enabled="1" pass="0">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="243,87,204,0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/qgreenland/config/datasets.yml
+++ b/qgreenland/config/datasets.yml
@@ -342,3 +342,18 @@ The images and data are produced in a consistent way that makes the Index time-s
     citation:
       text: 'Fetterer, F., K. Knowles, W. N. Meier, M. Savoie, and A. K. Windnagel. 2017, updated daily. Sea Ice Index, Version 3. Boulder, Colorado USA. NSIDC: National Snow and Ice Data Center. doi: https://doi.org/10.7265/N5K072F8. 2020-08-06.'
       url: 'https://nsidc.org/data/g02135'
+
+
+- id: utm_zones
+  access_method: http
+  sources:
+    - id: only
+      urls:
+        - 'http://sandbox.idre.ucla.edu/mapshare/data/world/data/utmzone.zip'
+  metadata:
+    title: 'World UTM Zones'
+    abstract: 'World UTM Zones represents the Universal Transverse Mercator (UTM) zones of the world. The polygons represent the Universal Transverse Mercator (UTM) zones, which, lie between 84 degrees North and 80 degrees South latitude. With few exceptions, they divide the world into sixty zones, each of which is six degrees of longitude wide. The zones are numbered from 1 through 60 eastward from 180 degrees West longitude. The zone characters designate eight degrees of latitude high rows extending north and south from the equator with the exception of the northern-most row which is 12 degrees high.'
+    # Is this citation good enough? Find another source?
+    citation:
+      text: 'ESRI Data & Maps. 2015.'
+      url: 'https://apps.gis.ucla.edu/geodata/dataset/world_utm_zones'

--- a/qgreenland/config/layer_groups.yml
+++ b/qgreenland/config/layer_groups.yml
@@ -1,16 +1,12 @@
 Miscellaneous:
   visible: False
-  expanded: False
+  expanded: True
 
 Miscellaneous/Place names:
   visible: False
   expanded: False
 
 Miscellaneous/Arctic circle:
-  visible: False
-  expanded: False
-
-Miscellaneous/UTM zones:
   visible: False
   expanded: False
 

--- a/qgreenland/config/layers.yml
+++ b/qgreenland/config/layers.yml
@@ -5,11 +5,12 @@
 - id: utm_zones
   title: Universal Transverse Mercator (UTM) Zones
   data_source: utm_zones.only
-  ingest_task: zipped_shapefile
+  ingest_task: utm_zones
   file_type: '.shp'
   data_type: 'vector'
   visible: False
   group_path: 'Miscellaneous'
+  style: 'transparent_shape'
 
 
 ###########

--- a/qgreenland/config/layers.yml
+++ b/qgreenland/config/layers.yml
@@ -1,3 +1,17 @@
+#################
+# Miscellaneous #
+#################
+
+- id: utm_zones
+  title: Universal Transverse Mercator (UTM) Zones
+  data_source: utm_zones.only
+  ingest_task: zipped_shapefile
+  file_type: '.shp'
+  data_type: 'vector'
+  visible: False
+  group_path: 'Miscellaneous'
+
+
 ###########
 # Biology #
 ###########

--- a/qgreenland/tasks/common/shapefile.py
+++ b/qgreenland/tasks/common/shapefile.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import luigi
@@ -5,7 +6,11 @@ import luigi
 from qgreenland.constants import TaskType
 from qgreenland.util.luigi import LayerTask
 from qgreenland.util.misc import find_single_file_by_ext, temporary_path_dir
-from qgreenland.util.shapefile import reproject_shapefile, subset_shapefile
+from qgreenland.util.shapefile import (filter_shapefile,
+                                       reproject_shapefile,
+                                       subset_shapefile)
+
+logger = logging.getLogger('luigi-interface')
 
 
 class ReprojectShapefile(LayerTask):
@@ -42,3 +47,23 @@ class SubsetShapefile(LayerTask):
         with temporary_path_dir(self.output()) as temp_path:
             fn = os.path.join(temp_path, self.filename)
             subset_shapefile(shapefile, layer_cfg=self.layer_cfg, outfile=fn)
+
+
+class FilterShapefileFeatures(LayerTask):
+    task_type = TaskType.WIP
+    filter_func = luigi.Parameter()
+
+    def output(self):
+        return luigi.LocalTarget(f'{self.outdir}/filter/')
+
+    def run(self):
+        logger.info(f"Filtering {self.layer_cfg['id']}...")
+        shapefile = find_single_file_by_ext(self.input().path, ext='.shp')
+        gdf = filter_shapefile(
+            shapefile,
+            filter_func=self.filter_func
+        )
+
+        with temporary_path_dir(self.output()) as temp_path:
+            fn = os.path.join(temp_path, self.filename)
+            gdf.to_file(fn, driver='ESRI Shapefile')

--- a/qgreenland/tasks/layers/__init__.py
+++ b/qgreenland/tasks/layers/__init__.py
@@ -7,6 +7,7 @@ from qgreenland.tasks.layers.ice_thickness_change import IceThicknessChange
 from qgreenland.tasks.layers.permaice import Permaice
 from qgreenland.tasks.layers.rarred_shapefile import RarredShapefile
 from qgreenland.tasks.layers.raster import Raster
+from qgreenland.tasks.layers.utm_zones import UtmZones
 from qgreenland.tasks.layers.velocity_mosaic import VelocityMosaic
 from qgreenland.tasks.layers.zipped_shapefile import ZippedShapefile
 
@@ -20,6 +21,7 @@ INGEST_TASKS = {
     'permaice': Permaice,
     'rarred_shapefile': RarredShapefile,
     'raster': Raster,
+    'utm_zones': UtmZones,
     'velocity_mosaic': VelocityMosaic,
     'zipped_shapefile': ZippedShapefile,
 }

--- a/qgreenland/tasks/layers/utm_zones.py
+++ b/qgreenland/tasks/layers/utm_zones.py
@@ -1,0 +1,38 @@
+"""Exactly like a zipped shapefile, but supports feature filtering."""
+
+from qgreenland.tasks.common.fetch import FetchDataFiles
+from qgreenland.tasks.common.misc import Unzip
+from qgreenland.tasks.common.shapefile import (FilterShapefileFeatures,
+                                               ReprojectShapefile,
+                                               SubsetShapefile)
+from qgreenland.util.luigi import LayerPipeline
+
+
+class UtmZones(LayerPipeline):
+    """Rename files to their final location."""
+
+    def requires(self):
+        fetch_data = FetchDataFiles(
+            source_cfg=self.cfg['source'],
+            output_name=self.cfg['id']
+        )  # ->
+        unzip = Unzip(
+            requires_task=fetch_data,
+            layer_id=self.layer_id
+        )  # ->
+        filter_shapefile = FilterShapefileFeatures(
+            requires_task=unzip,
+            layer_id=self.layer_id,
+            # The UTM Zones file includes a Zone 0 which overlaps all the other
+            # zones. It looked bad so I removed it. Should we solve this some
+            # other way?
+            filter_func=lambda df: df['ZONE'] != 0,
+        )  # ->
+        reproject_shapefile = ReprojectShapefile(
+            requires_task=filter_shapefile,
+            layer_id=self.layer_id
+        )  # ->
+        return SubsetShapefile(
+            requires_task=reproject_shapefile,
+            layer_id=self.layer_id
+        )

--- a/qgreenland/util/shapefile.py
+++ b/qgreenland/util/shapefile.py
@@ -9,6 +9,13 @@ from qgreenland.constants import PROJECT_CRS, PROJECT_EXTENT
 logger = logging.getLogger('luigi-interface')
 
 
+def filter_shapefile(shapefile_path, *, filter_func):
+    gdf = geopandas.read_file(shapefile_path)
+
+    gdf = gdf.loc[filter_func]
+    return gdf
+
+
 def reproject_shapefile(shapefile_path, *, layer_cfg):
     """Reprojects a shapefile and returns the result."""
     gdf = geopandas.read_file(shapefile_path)


### PR DESCRIPTION
Added a "filter shapefile" job which takes a lambda filter condition as an argument. We use it to remove UTM Zone 0 which overlaps with all the other zones, making it impossible to select 1. It may be only the antarctic Zone 0 that was a problem. Should test removing only one of the Zone 0 polygons instead of both. Or doing something else. :shrug: