### PR TITLE
Zipped QGreenland package's root dir is named same as package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   appropriate.
 - Fixup issue with ice firn and racmo wind vector layers that had numerical
   fields incorrectly cast to `string`.
+- Zipped package root directory now reflects the name of the zip file. For
+  example, `QGreenland_v1.0.0.zip` will be extracted to a `QGreenland_v1.0.0/`
+  directory instead of `qgreenland/`.
 
 # v0.50.0 (2021-01-07)
 

--- a/qgreenland/constants.py
+++ b/qgreenland/constants.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 from qgreenland.util.version import get_build_version, version_is_full_release
 
-PROJECT = 'qgreenland'
+PROJECT = 'QGreenland'
 
 ENVIRONMENT = os.environ.get('ENVIRONMENT', 'dev')
 


### PR DESCRIPTION
Now when a user unzips the package, the name of the extracted dir is the same
name as the zip archive.

This prevents the possibility of someone e.g. downloading a newer version of
QGreenland that gets unpacked into an older version.