### PR TITLE
Use `ensure_group_exists` in `_set_groups_options`

### DIFF
--- a/qgreenland/util/qgis.py
+++ b/qgreenland/util/qgis.py
@@ -186,12 +186,13 @@ def _set_groups_options(project):
     groups_config = CONFIG['layer_groups']
 
     for group_path, options in groups_config.items():
-        group = _get_group(project, group_path)
-
+        group = _ensure_group_exists(project, group_path)
+ 
         _set_group_visibility(
             group,
             options.get('visible', LAYERGROUP_VISIBLE_DEFAULT)
         )
+
         _set_group_expanded(
             group,
             options.get('expanded', LAYERGROUP_EXPANDED_DEFAULT)

--- a/qgreenland/util/qgis.py
+++ b/qgreenland/util/qgis.py
@@ -187,7 +187,7 @@ def _set_groups_options(project):
 
     for group_path, options in groups_config.items():
         group = _ensure_group_exists(project, group_path)
- 
+
         _set_group_visibility(
             group,
             options.get('visible', LAYERGROUP_VISIBLE_DEFAULT)


### PR DESCRIPTION
Otherwise group paths that have not been previously created will
fail. `_get_group` simply returns `None`.