### PR TITLE
Avoid special chars `>` and `:` in layer titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.0.0 (2021-02-22)
 
 - Enable Greenland coastline layer by default, add semitransparent fill.
+- Avoid use of special characters in layer titles for Windows compatibility.
 
 # v1.0.0rc2 (2021-02-11)
 

--- a/qgreenland/config/layers.yml
+++ b/qgreenland/config/layers.yml
@@ -2111,7 +2111,7 @@
 ###########
 
 - id: earthquakes
-  title: 'Earthquakes M>2.5 1900-2020'
+  title: 'Earthquakes M above 2.5 1900-2020'
   description: >-
     Location and magnitude of earthquakes.
   visible: False
@@ -5700,7 +5700,7 @@
     scale: 0.01
 
 - id: dms_gtk_topo
-  title: 'Topographic map (1:500,000)'
+  title: 'Topographic map (1 to 500,000)'
   description: >-
     Digitized and geolocated topographic map of Greenland.
   visible: False


### PR DESCRIPTION
Fixes #214