### PR TITLE
Stop using list for step helper arg defaults :bell:

### DIFF
--- a/qgreenland/_typing.py
+++ b/qgreenland/_typing.py
@@ -3,10 +3,12 @@
 NOTE: This module is named strangely to avoid conflicts with the stdlib's
 `types` module.
 """
-from typing import Literal
+from typing import Literal, Union
 
 
 QgsLayerType = Literal['Vector', 'Raster', 'Online']
 QgsLayerProviderType = Literal['gdal', 'ogr', 'wms', 'wfs', 'wcs']
 
 ResamplingMethod = Literal['bilinear', 'nearest']
+
+StepArgs = Union[tuple, list]

--- a/qgreenland/config/helpers/steps/compressed_vector.py
+++ b/qgreenland/config/helpers/steps/compressed_vector.py
@@ -1,5 +1,6 @@
 from types import MappingProxyType
 
+from qgreenland._typing import StepArgs
 from qgreenland.config.helpers.steps.decompress import decompress_step
 from qgreenland.config.helpers.steps.ogr2ogr import ogr2ogr
 from qgreenland.config.project import project
@@ -22,8 +23,7 @@ def compressed_vector(
     output_file: str,
     vector_filename: str = '*.shp',
     decompress_step_kwargs=default_decompress_step_kwargs,
-    # TODO: boundary_filepath, ogr2ogr_args -> ogr2ogr_kwargs?
-    ogr2ogr_args: list[str] = [],
+    ogr2ogr_args: StepArgs = (),
     boundary_filepath: EvalFilePath = project.boundaries['background'].filepath,
 ) -> list[ConfigLayerCommandStep]:
     """Unzip a vector data file and reproject."""

--- a/qgreenland/config/helpers/steps/gdal_edit.py
+++ b/qgreenland/config/helpers/steps/gdal_edit.py
@@ -1,3 +1,4 @@
+from qgreenland._typing import StepArgs
 from qgreenland.models.config.step import ConfigLayerCommandStep
 
 
@@ -5,7 +6,7 @@ def gdal_edit(
     *,
     input_file: str,
     output_file: str,
-    gdal_edit_args: list[str],
+    gdal_edit_args: StepArgs = (),
 ) -> list[ConfigLayerCommandStep]:
 
     return [ConfigLayerCommandStep(

--- a/qgreenland/config/helpers/steps/ogr2ogr.py
+++ b/qgreenland/config/helpers/steps/ogr2ogr.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from qgreenland._typing import StepArgs
 from qgreenland.config.project import project
 from qgreenland.models.config.step import ConfigLayerCommandStep
 from qgreenland.util.runtime_vars import EvalFilePath
@@ -17,7 +18,7 @@ def ogr2ogr(
     input_file: str,
     output_file: str,
     boundary_filepath: EvalFilePath = project.boundaries['background'].filepath,
-    ogr2ogr_args: list[str] = [],
+    ogr2ogr_args: StepArgs = (),
     enable_partial_reprojection=False,
 ) -> list[ConfigLayerCommandStep]:
     """Warp to project CRS and do other stuff as specified in args."""

--- a/qgreenland/config/helpers/steps/warp.py
+++ b/qgreenland/config/helpers/steps/warp.py
@@ -1,4 +1,4 @@
-from qgreenland._typing import ResamplingMethod
+from qgreenland._typing import ResamplingMethod, StepArgs
 from qgreenland.config.project import project
 from qgreenland.models.config.step import ConfigLayerCommandStep
 from qgreenland.util.runtime_vars import EvalFilePath
@@ -10,7 +10,7 @@ def warp(
     output_file: str,
     cut_file: EvalFilePath,
     resampling_method: ResamplingMethod = 'bilinear',
-    warp_args: list[str] = [],
+    warp_args: StepArgs = (),
 ) -> list[ConfigLayerCommandStep]:
 
     return [ConfigLayerCommandStep(

--- a/qgreenland/config/helpers/steps/warp_and_cut.py
+++ b/qgreenland/config/helpers/steps/warp_and_cut.py
@@ -1,4 +1,4 @@
-from qgreenland._typing import ResamplingMethod
+from qgreenland._typing import ResamplingMethod, StepArgs
 from qgreenland.config.project import project
 from qgreenland.models.config.step import ConfigLayerCommandStep
 
@@ -11,8 +11,8 @@ def warp_and_cut(
     output_file,
     cut_file,
     resampling_method: ResamplingMethod = 'bilinear',
-    reproject_args: list[str] = [],
-    cut_args: list[str] = [],
+    reproject_args: StepArgs = (),
+    cut_args: StepArgs = (),
 ) -> list[ConfigLayerCommandStep]:
     reproject = ConfigLayerCommandStep(
         args=[


### PR DESCRIPTION
Using lists is a flake8 violation :bell: :

```
B006 Do not use mutable data structures for argument defaults.  They are created
during function definition time. All calls to the function reuse this one
instance of that data structure, persisting changes between them.
```