### PR TITLE
Catch `KeyboardInterrupt` in `temporary_path_dir` and cleanup

### DIFF
--- a/qgreenland/util/luigi/target.py
+++ b/qgreenland/util/luigi/target.py
@@ -18,7 +18,7 @@ def temporary_path_dir(target: luigi.Target) -> Generator[Path, None, None]:
         try:
             path.mkdir(parents=True, exist_ok=True)
             yield path
-        except Exception as e:
+        except (Exception, KeyboardInterrupt) as e:
             shutil.rmtree(path)
             raise e
     return


### PR DESCRIPTION
This will allow us to safely ctrl-c to stop execution and still have the tmp dir
created by `temporary_path_dir` get cleaned up.