### PR TITLE
Allow nginx to index layers and packages

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -9,4 +9,5 @@ COPY ./openssl.conf .
 RUN openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -config openssl.conf \
     -keyout /cert/ssl.key -out /cert/ssl.crt
 
+RUN rm /usr/share/nginx/html/*
 # TODO: Consider baking the full config in the image instead of using compose? ¯\_(ツ)_/¯


### PR DESCRIPTION
## Description

Fix nginx index page from a default `index.html` to an autoindex of our mounted volumes (layers, packages).


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] CHANGELOG.md updated (not needed)
- [x] Documentation updated (not needed)
- [x] Version bumped (not needed)
- [x] New unit tests (not needed)
