### PR TITLE
Fix capitalization issue with onshore_planar layer

### DIFF
--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -11063,7 +11063,7 @@
                         "{input_dir}/as_2159.zip",
                         "-d",
                         "{output_dir}",
-                        "data/shape/geology/Greenland_onshore_planar.*"
+                        "data/shape/geology/Greenland_onshore_Planar.*"
                       ],
                       "type": "command"
                     },
@@ -11078,7 +11078,7 @@
                         "{assets_dir}/latitude_shape_40_degrees.geojson",
                         "-makevalid",
                         "{output_dir}/final.gpkg",
-                        "{input_dir}/data/shape/geology/Greenland_onshore_planar.shp"
+                        "{input_dir}/data/shape/geology/Greenland_onshore_Planar.shp"
                       ],
                       "type": "command"
                     }

--- a/qgreenland/config/helpers/layers/geological_map.py
+++ b/qgreenland/config/helpers/layers/geological_map.py
@@ -11,8 +11,7 @@ LAYER_PARAMS = {
             """Onshore faults for the landmass and islands of Greenland."""
         ),
         'style': 'onshore_planar_geological_map',
-        'input_filepath': 'data/shape/geology/Greenland_onshore_planar',
-        'fn_mask': 'Greenland_onshore_Planar.*',
+        'input_filepath': 'data/shape/geology/Greenland_onshore_Planar',
     },
     'onshore_geological_map': {
         'title': 'Rock types',
@@ -22,7 +21,6 @@ LAYER_PARAMS = {
         ),
         'style': 'geological_map_polygons',
         'input_filepath': 'data/shape/geology/Greenland_onshore',
-        'fn_mask': 'Greenland_onshore.*',
     },
     'greenland_ice': {
         'title': 'Ice thickness contours',
@@ -33,7 +31,6 @@ LAYER_PARAMS = {
         ),
         'style': 'greenland_ice',
         'input_filepath': 'data/shape/base/Greenland_ice',
-        'fn_mask': 'Greenland_ice.*',
     },
 }
 


### PR DESCRIPTION
## Description

Fix capitalization issue with geology layer. Did this layer succeed in the past because of OSX's case-insensitive filesystem?


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
