### PR TITLE
Update seaice index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - "Geophysics/Heat flux/Flow measurement locations"
   - "Oceanography/Bathymetry/Depth contours"
   - "Geology/Geological map/Ice thickness contours"
+  - "Sea ice/Monthly mean concentration (25 km)/September (min monthly extent)/September 2021"
+  - "Sea ice/Monthly mean concentration (25 km)/Feb or March (max monthly extent)/March 2021"
 
 # v2.0.0alpha1 (2021-11-03)
 

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -1415,6 +1415,13 @@
           ],
           "verify_tls": true
         },
+        "maximum_concentration_2021": {
+          "id": "maximum_concentration_2021",
+          "urls": [
+            "ftp://sidads.colorado.edu/DATASETS/NOAA/G02135/north/monthly/geotiff/03_Mar/N_202103_concentration_v3.0.tif"
+          ],
+          "verify_tls": true
+        },
         "median_extent_line_01": {
           "id": "median_extent_line_01",
           "urls": [
@@ -1573,6 +1580,13 @@
           "id": "minimum_concentration_2020",
           "urls": [
             "ftp://sidads.colorado.edu/DATASETS/NOAA/G02135/north/monthly/geotiff/09_Sep/N_202009_concentration_v3.0.tif"
+          ],
+          "verify_tls": true
+        },
+        "minimum_concentration_2021": {
+          "id": "minimum_concentration_2021",
+          "urls": [
+            "ftp://sidads.colorado.edu/DATASETS/NOAA/G02135/north/monthly/geotiff/09_Sep/N_202109_concentration_v3.0.tif"
           ],
           "verify_tls": true
         }
@@ -20514,6 +20528,81 @@
                       "title": "September 2020"
                     },
                     "name": "seaice_minimum_concentration_2020"
+                  },
+                  {
+                    "layer_cfg": {
+                      "description": "Monthly average of sea ice concentration as a percentage (e.g., 99.9 =\n99.9%). Values under 15% are considered to be open water.",
+                      "id": "seaice_minimum_concentration_2021",
+                      "in_package": true,
+                      "input": {
+                        "asset": {
+                          "id": "minimum_concentration_2021"
+                        },
+                        "dataset": {
+                          "id": "seaice_index"
+                        }
+                      },
+                      "show": false,
+                      "steps": [
+                        {
+                          "args": [
+                            "gdal_calc.py",
+                            "--calc",
+                            "'A / 10.0'",
+                            "-A",
+                            "{input_dir}/*.tif",
+                            "--outfile={output_dir}/downscaled.tif"
+                          ],
+                          "type": "command"
+                        },
+                        {
+                          "args": [
+                            "gdalwarp",
+                            "-t_srs",
+                            "EPSG:3413",
+                            "-r",
+                            "bilinear",
+                            "{input_dir}/downscaled.tif",
+                            "{output_dir}/warped.tif"
+                          ],
+                          "type": "command"
+                        },
+                        {
+                          "args": [
+                            "gdalwarp",
+                            "-cutline",
+                            "{assets_dir}/latitude_shape_40_degrees.geojson",
+                            "-crop_to_cutline",
+                            "-co",
+                            "COMPRESS=DEFLATE",
+                            "{input_dir}/warped.tif",
+                            "{output_dir}/warped_and_cut.tif"
+                          ],
+                          "type": "command"
+                        },
+                        {
+                          "args": [
+                            "cp",
+                            "{input_dir}/warped_and_cut.tif",
+                            "{output_dir}/overviews.tif",
+                            "&&",
+                            "gdaladdo",
+                            "-r",
+                            "average",
+                            "{output_dir}/overviews.tif",
+                            "2",
+                            "4",
+                            "8",
+                            "16"
+                          ],
+                          "type": "command"
+                        }
+                      ],
+                      "style": "sea_ice_concentration",
+                      "tags": [],
+                      "title": "September 2021"
+                    },
+                    "name": "seaice_minimum_concentration_2021"
                   }
                 ],
                 "name": "September (min monthly extent)",
@@ -21349,6 +21438,81 @@
                       "title": "March 2020"
                     },
                     "name": "seaice_maximum_concentration_2020"
+                  },
+                  {
+                    "layer_cfg": {
+                      "description": "Monthly average of sea ice concentration as a percentage (e.g., 99.9 =\n99.9%). Values under 15% are considered to be open water.",
+                      "id": "seaice_maximum_concentration_2021",
+                      "in_package": true,
+                      "input": {
+                        "asset": {
+                          "id": "maximum_concentration_2021"
+                        },
+                        "dataset": {
+                          "id": "seaice_index"
+                        }
+                      },
+                      "show": false,
+                      "steps": [
+                        {
+                          "args": [
+                            "gdal_calc.py",
+                            "--calc",
+                            "'A / 10.0'",
+                            "-A",
+                            "{input_dir}/*.tif",
+                            "--outfile={output_dir}/downscaled.tif"
+                          ],
+                          "type": "command"
+                        },
+                        {
+                          "args": [
+                            "gdalwarp",
+                            "-t_srs",
+                            "EPSG:3413",
+                            "-r",
+                            "bilinear",
+                            "{input_dir}/downscaled.tif",
+                            "{output_dir}/warped.tif"
+                          ],
+                          "type": "command"
+                        },
+                        {
+                          "args": [
+                            "gdalwarp",
+                            "-cutline",
+                            "{assets_dir}/latitude_shape_40_degrees.geojson",
+                            "-crop_to_cutline",
+                            "-co",
+                            "COMPRESS=DEFLATE",
+                            "{input_dir}/warped.tif",
+                            "{output_dir}/warped_and_cut.tif"
+                          ],
+                          "type": "command"
+                        },
+                        {
+                          "args": [
+                            "cp",
+                            "{input_dir}/warped_and_cut.tif",
+                            "{output_dir}/overviews.tif",
+                            "&&",
+                            "gdaladdo",
+                            "-r",
+                            "average",
+                            "{output_dir}/overviews.tif",
+                            "2",
+                            "4",
+                            "8",
+                            "16"
+                          ],
+                          "type": "command"
+                        }
+                      ],
+                      "style": "sea_ice_concentration",
+                      "tags": [],
+                      "title": "March 2021"
+                    },
+                    "name": "seaice_maximum_concentration_2021"
                   }
                 ],
                 "name": "Feb or March (max monthly extent)",

--- a/qgreenland/config/datasets/seaice.py
+++ b/qgreenland/config/datasets/seaice.py
@@ -62,7 +62,7 @@ seaice_index = ConfigDataset(
 )
 
 # NOTE: when updating the assets for this dataset, the
-# `config/helpers/layers/make_sea_ice_age_params.py` script needs to be re-run to
+# `scripts/data/make_sea_ice_age_params.py` script needs to be re-run to
 # generate the `config/helpers/ancillary/sea_ice_age_params.json` file. The
 # parameters contained in the `sea_ice_age_params.json` file are necessary for
 # layer creation.

--- a/qgreenland/config/helpers/layers/sea_ice_concentration.py
+++ b/qgreenland/config/helpers/layers/sea_ice_concentration.py
@@ -3,7 +3,7 @@ import calendar
 from qgreenland.models.config.asset import ConfigDatasetHttpAsset
 
 
-END_YEAR = 2020
+END_YEAR = 2021
 CONCENTRATION_YEARS = range(2010, END_YEAR + 1)
 CONCENTRATION_DESCRIPTION = (
     """Monthly average of sea ice concentration as a percentage (e.g., 99.9 =


### PR DESCRIPTION
## Description

Update the sea ice index dataset to include min/max concentrations from 2021.

Note that sea ice age data for 2021 is not available for NSIDC-0611 until the start of next year. There is 'near real time' data available via NSIDC-0749, but I think we should just wait until the next update to NSIDC-0611 to include that data.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
