### PR TITLE
Update coastline style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@
     extent)/September 2021"
   - "Sea ice/Monthly mean concentration (25 km)/Feb or March (max monthly
     extent)/March 2021"
-- Move "Geophysics/Geothermal heat flux (5km)" layer to "Geophysics/Heat
-  flux/Flux from ice cores (Greve, R.) (5km)".
-- Move "Oceanography/Bathymetric chart of the Arctic Ocean (400m)" to
-  "Oceanography/Bathymetry/Depth (400m)"
-- Update "Regional climate models/RACMO model output/Runoff 1958-2019 (1km)"
-  layer: change colormap, make `0` values transarent.
-- Update "Reference/Timezones" layer to include a label.
+- Move layers:
+  - "Geophysics/Geothermal heat flux (5km)" layer to "Geophysics/Heat
+    flux/Flux from ice cores (Greve, R.) (5km)".
+  - "Oceanography/Bathymetric chart of the Arctic Ocean (400m)" to
+    "Oceanography/Bathymetry/Depth (400m)"
+- Update layers:
+  - "Regional climate models/RACMO model output/Runoff 1958-2019 (1km)": change
+    colormap, make `0` values transarent.
+  - "Reference/Timezones": add labels.
+  - "Reference/Borders/Greenland coastlines": update style to remove green
+    tint.
 
 
 # v2.0.0alpha1 (2021-11-03)

--- a/qgreenland/ancillary/styles/greenland_coastline.qml
+++ b/qgreenland/ancillary/styles/greenland_coastline.qml
@@ -1,25 +1,25 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Symbology|Labeling" labelsEnabled="0" version="3.10.4-A Coruña">
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis styleCategories="Symbology" version="3.16.3-Hannover">
+  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
     <symbols>
-      <symbol alpha="0.25" name="0" force_rhr="0" clip_to_extent="1" type="fill">
-        <layer pass="0" locked="0" enabled="1" class="SimpleFill">
+      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
           <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="1,255,22,255" k="color"/>
+          <prop v="255,255,255,0" k="color"/>
           <prop v="bevel" k="joinstyle"/>
           <prop v="0,0" k="offset"/>
           <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
           <prop v="MM" k="offset_unit"/>
           <prop v="35,35,35,255" k="outline_color"/>
           <prop v="solid" k="outline_style"/>
-          <prop v="0.4" k="outline_width"/>
+          <prop v="0.5" k="outline_width"/>
           <prop v="MM" k="outline_width_unit"/>
           <prop v="solid" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>


### PR DESCRIPTION
Remove green tint, thicken outline

## Description

Make the coastline layer (default enabled) look better. Remove green tint, thicken lines.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
