### PR TITLE
Note symbology in Arctic DEM layer

### DIFF
--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -23011,7 +23011,7 @@
           },
           {
             "layer_cfg": {
-              "description": "Surface elevation in meters.",
+              "description": "Surface elevation in meters using hillshade symbology.",
               "id": "arctic_dem",
               "in_package": true,
               "input": {

--- a/qgreenland/config/layers/Terrain models/arctic_dem.py
+++ b/qgreenland/config/layers/Terrain models/arctic_dem.py
@@ -12,7 +12,7 @@ arctic_dem = ConfigLayer(
     id='arctic_dem',
     title='Arctic DEM (100m)',
     description=(
-        """Surface elevation in meters."""
+        """Surface elevation in meters using hillshade symbology."""
     ),
     tags=[],
     style='arctic_dem',


### PR DESCRIPTION
## Description

Clarify the Arctic DEM layer's symbology in the description. Some users reported confusion that we provided hillshade imagery instead of the actual data. In fact, we did provide the actual data, and QGIS stylized it as hillshade. Should we simply avoid hillshade? Is there a way to create a "virtual copy" of a layer with a different style, so a layer could be delivered with two styles to make this clearer?


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
