### PR TITLE
CLI flag to run without zipping

### DIFF
--- a/qgreenland/cli/cleanup.py
+++ b/qgreenland/cli/cleanup.py
@@ -33,6 +33,7 @@ def _print_and_run(cmd, *, dry_run):
 @click.option('dry_run', '--dry-run', '-d',
               help="Print commands, but don't actually delete anything.",
               is_flag=True)
+# TODO: Rename "fetch"
 @click.option('delete_inputs_by_pattern', '--delete-inputs-by-pattern', '-i',
               help=(
                   'Bash glob/brace pattern used to delete input datasources by'

--- a/qgreenland/util/luigi/tasks/pipeline.py
+++ b/qgreenland/util/luigi/tasks/pipeline.py
@@ -228,3 +228,9 @@ class QGreenlandAll(luigi.WrapperTask):
     def requires(self):
         yield ZipQGreenland()
         yield HostedLayers()
+
+
+class QGreenlandNoZip(luigi.WrapperTask):
+    def requires(self):
+        yield CreateQgisProjectFile()
+        yield HostedLayers()


### PR DESCRIPTION
## Description

Sometimes you want to run the whole pipeline without zipping in dev. `-Z` does that now. 


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
