### PR TITLE
Int for basal thermal state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # v2.0.0alpha3 (2021-11-23)
 
 - Improved raster compression.
-- Convert RACMO promice mask layers to `Byte` data type.
-- Update Bedmachine dataset metadata to reflect new v4 data.
+- Layer Updates:
+  - Convert RACMO promice mask layers to `Byte` data type.
+  - Update Bedmachine dataset metadata to reflect new v4 data.
+  - Convert "Likely basal thermal state June 23 1993 - April 26 2013 (5km)"
+    layer to `Int16` data type.
 
 
 # v2.0.0alpha2 (2021-11-22)

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -11632,6 +11632,20 @@
                 },
                 {
                   "args": [
+                    "gdal_calc.py",
+                    "--type",
+                    "Int16",
+                    "--NoDataValue",
+                    "3",
+                    "--calc=\"nan_to_num(A, nan=3)\"",
+                    "-A",
+                    "{input_dir}/basal_thermal_state.tif",
+                    "--outfile={output_dir}/basal_thermal_state.tif"
+                  ],
+                  "type": "command"
+                },
+                {
+                  "args": [
                     "cp",
                     "{input_dir}/basal_thermal_state.tif",
                     "{output_dir}/basal_thermal_state.tif",
@@ -11641,8 +11655,6 @@
                     "-632500.0 -667500.0 847500.0 -3342500.0",
                     "-a_srs",
                     "EPSG:3413",
-                    "-a_nodata",
-                    "3",
                     "{output_dir}/basal_thermal_state.tif"
                   ],
                   "type": "command"
@@ -11653,7 +11665,7 @@
                     "-co",
                     "COMPRESS=DEFLATE",
                     "-co",
-                    "PREDICTOR=3",
+                    "PREDICTOR=2",
                     "{input_dir}/basal_thermal_state.tif",
                     "{output_dir}/compressed.tif"
                   ],

--- a/qgreenland/config/layers/Glaciology/basal_thermal_state.py
+++ b/qgreenland/config/layers/Glaciology/basal_thermal_state.py
@@ -26,24 +26,33 @@ basal_thermal_state = Layer(
                 '{output_dir}/basal_thermal_state.tif',
             ],
         ),
+        # Convert the dataset to `Int16` data type to save a little extra space
+        # in the final output.
+        CommandStep(
+            args=[
+                'gdal_calc.py',
+                '--type', 'Int16',
+                # Set a nodata value of 3. This value does not occur in the data
+                # (valid values are -1, 0, 1).
+                '--NoDataValue', '3',
+                # This dataset contains nans. Replace them with the nodata value (3)
+                '--calc="nan_to_num(A, nan=3)"',
+                '-A', '{input_dir}/basal_thermal_state.tif',
+                '--outfile={output_dir}/basal_thermal_state.tif',
+            ],
+        ),
         *gdal_edit(
             input_file='{input_dir}/basal_thermal_state.tif',
             output_file='{output_dir}/basal_thermal_state.tif',
             gdal_edit_args=[
                 '-a_ullr', '-632500.0 -667500.0 847500.0 -3342500.0',
                 '-a_srs', 'EPSG:3413',
-                # Set a nodata value of 3. This value does not occur in the data
-                # (valid values are -1, 0, 1). There _are_ `nan` values in this
-                # data, and they show up in QGIS if nodata is unset. Setting
-                # nodata to `nan` works, but causes the next step (building
-                # overviews) to hang indefinitely.
-                '-a_nodata', '3',
             ],
         ),
         *compress_and_add_overviews(
             input_file='{input_dir}/basal_thermal_state.tif',
             output_file='{output_dir}/basal_thermal_state.tif',
-            dtype_is_float=True,
+            dtype_is_float=False,
         ),
     ],
 )


### PR DESCRIPTION
## Description

Cast basal thermal state layer to Int16. Saves us an entire **71KB**!


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
