### PR TITLE
Export layer metadata txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
     reference layers
   - "Basemaps/Background (500m)": Use JPEG compression to significantly reduce
     file size
+- Add metadata.txt with layer information to layer data directory. This allows
+  users who are not using the QGreenland project to access e.g., the layer's
+  abstract and citation information.
 
 
 # v2.0.0alpha3 (2021-11-23)

--- a/qgreenland/test/util/test_metadata.py
+++ b/qgreenland/test/util/test_metadata.py
@@ -1,0 +1,42 @@
+import copy
+
+import qgreenland.util.metadata as qgm
+
+
+def test__build_dataset_description(raster_layer_cfg):
+    actual = qgm._build_dataset_description(raster_layer_cfg)
+    expected = """Example Dataset
+
+Example abstract."""
+
+    assert actual == expected
+
+
+def __build_dataset_citation(raster_layer_cfg):
+    actual = qgm._build_dataset_citation(raster_layer_cfg)
+    expected = """Citation:
+NSIDC 2020
+
+Citation URL:
+https://nsidc.org"""
+
+    assert actual == expected
+
+
+def test_build_abstract(raster_layer_cfg):
+    mock_cfg = copy.deepcopy(raster_layer_cfg)
+    actual = qgm.build_layer_metadata(mock_cfg)
+    expected = """Example layer description.
+
+=== Original Data Source ===
+Example Dataset
+
+Example abstract.
+
+Citation:
+NSIDC 2020
+
+Citation URL:
+https://nsidc.org"""
+
+    assert actual == expected

--- a/qgreenland/test/util/test_qgis.py
+++ b/qgreenland/test/util/test_qgis.py
@@ -59,7 +59,7 @@ def test_add_layer_metadata(setup_teardown_qgis_app, raster_layer_node):
 
     # The abstract gets set with the value returned by `qgis.build_abstract`.
     assert mock_raster_layer.metadata().abstract() == \
-        qgm.build_layer_abstract(raster_layer_node.layer_cfg)
+        qgm.build_layer_metadata(raster_layer_node.layer_cfg)
 
     actual_title = mock_raster_layer.metadata().title()
     expected_title = raster_layer_node.layer_cfg.title
@@ -96,7 +96,7 @@ https://nsidc.org"""
 
 def test_build_abstract(raster_layer_cfg):
     mock_cfg = copy.deepcopy(raster_layer_cfg)
-    actual = qgm.build_layer_abstract(mock_cfg)
+    actual = qgm.build_layer_metadata(mock_cfg)
     expected = """Example layer description.
 
 === Original Data Source ===

--- a/qgreenland/test/util/test_qgis.py
+++ b/qgreenland/test/util/test_qgis.py
@@ -1,12 +1,11 @@
-import copy
 from unittest.mock import patch
 
 import pytest
 import qgis.core as qgc
 
 import qgreenland.exceptions as exc
+import qgreenland.util.metadata as qgm
 import qgreenland.util.qgis.layer as qgl
-import qgreenland.util.qgis.metadata as qgm
 import qgreenland.util.qgis.project as prj
 from qgreenland.test.constants import (
     MOCK_COMPILE_PACKAGE_DIR,
@@ -55,7 +54,7 @@ def test_make_map_layer_raster(setup_teardown_qgis_app, raster_layer_node):
 def test_add_layer_metadata(setup_teardown_qgis_app, raster_layer_node):
     mock_raster_layer = qgl.make_map_layer(raster_layer_node)
 
-    qgm.add_layer_metadata(mock_raster_layer, raster_layer_node.layer_cfg)
+    qgl.add_layer_metadata(mock_raster_layer, raster_layer_node.layer_cfg)
 
     # The abstract gets set with the value returned by `qgis.build_abstract`.
     assert mock_raster_layer.metadata().abstract() == \
@@ -72,45 +71,6 @@ def test_add_layer_metadata(setup_teardown_qgis_app, raster_layer_node):
     meta_extent = mock_raster_layer.metadata().extent().spatialExtents()[0]
     # The `expected_extent` is a QgsRectangle.
     assert expected_extent == meta_extent.bounds.toRectangle()
-
-
-def test__build_dataset_description(raster_layer_cfg):
-    actual = qgm._build_dataset_description(raster_layer_cfg)
-    expected = """Example Dataset
-
-Example abstract."""
-
-    assert actual == expected
-
-
-def __build_dataset_citation(raster_layer_cfg):
-    actual = qgm._build_dataset_citation(raster_layer_cfg)
-    expected = """Citation:
-NSIDC 2020
-
-Citation URL:
-https://nsidc.org"""
-
-    assert actual == expected
-
-
-def test_build_abstract(raster_layer_cfg):
-    mock_cfg = copy.deepcopy(raster_layer_cfg)
-    actual = qgm.build_layer_metadata(mock_cfg)
-    expected = """Example layer description.
-
-=== Original Data Source ===
-Example Dataset
-
-Example abstract.
-
-Citation:
-NSIDC 2020
-
-Citation URL:
-https://nsidc.org"""
-
-    assert actual == expected
 
 
 @patch(

--- a/qgreenland/util/config/export.py
+++ b/qgreenland/util/config/export.py
@@ -26,7 +26,7 @@ from qgreenland.util.layer import (
     vector_or_raster,
 )
 from qgreenland.util.qgis.metadata import (
-    build_layer_abstract,
+    build_layer_metadata,
 )
 from qgreenland.util.tree import LayerNode
 from qgreenland.util.version import get_build_version
@@ -54,7 +54,7 @@ def export_config_manifest(
             'id': layer_node.layer_cfg.id,
             **layer_node.layer_cfg.dict(include={'title', 'description', 'tags'}),
             'hierarchy': layer_node.group_name_path,
-            'layer_details': build_layer_abstract(layer_node.layer_cfg),
+            'layer_details': build_layer_metadata(layer_node.layer_cfg),
             'assets': _layer_manifest_final_assets(layer_node),
         } for layer_node in cfg.layer_tree.leaves],
     }

--- a/qgreenland/util/config/export.py
+++ b/qgreenland/util/config/export.py
@@ -25,7 +25,7 @@ from qgreenland.util.layer import (
     get_layer_release_filepath,
     vector_or_raster,
 )
-from qgreenland.util.qgis.metadata import (
+from qgreenland.util.metadata import (
     build_layer_metadata,
 )
 from qgreenland.util.tree import LayerNode

--- a/qgreenland/util/luigi/tasks/main.py
+++ b/qgreenland/util/luigi/tasks/main.py
@@ -19,7 +19,7 @@ from qgreenland.util.layer import (
 )
 from qgreenland.util.luigi.target import temporary_path_dir
 from qgreenland.util.provenance import write_provenance_file
-from qgreenland.util.qgis.metadata import build_layer_abstract
+from qgreenland.util.qgis.metadata import write_metadata_file
 from qgreenland.util.tree import leaf_lookup
 
 
@@ -169,7 +169,7 @@ class FinalizeTask(QgrLayerTask):
                 filepath=temp_path / 'provenance.txt',
             )
 
-            with open(temp_path / 'metadata.txt', 'w') as metadata_file:
-                metadata_file.write(
-                    build_layer_abstract(self.layer_cfg),
-                )
+            write_metadata_file(
+                layer_cfg=self.layer_cfg,
+                filepath=temp_path / 'metadata.txt',
+            )

--- a/qgreenland/util/luigi/tasks/main.py
+++ b/qgreenland/util/luigi/tasks/main.py
@@ -19,6 +19,7 @@ from qgreenland.util.layer import (
 )
 from qgreenland.util.luigi.target import temporary_path_dir
 from qgreenland.util.provenance import steps_to_provenance_text
+from qgreenland.util.qgis.metadata import build_layer_abstract
 from qgreenland.util.tree import leaf_lookup
 
 
@@ -166,4 +167,9 @@ class FinalizeTask(QgrLayerTask):
             with open(temp_path / 'provenance.txt', 'w') as provenance_file:
                 provenance_file.write(
                     steps_to_provenance_text(self.layer_cfg.steps),
+                )
+
+            with open(temp_path / 'metadata.txt', 'w') as metadata_file:
+                metadata_file.write(
+                    build_layer_abstract(self.layer_cfg),
                 )

--- a/qgreenland/util/luigi/tasks/main.py
+++ b/qgreenland/util/luigi/tasks/main.py
@@ -18,8 +18,8 @@ from qgreenland.util.layer import (
     get_layer_release_dir,
 )
 from qgreenland.util.luigi.target import temporary_path_dir
+from qgreenland.util.metadata import write_metadata_file
 from qgreenland.util.provenance import write_provenance_file
-from qgreenland.util.qgis.metadata import write_metadata_file
 from qgreenland.util.tree import leaf_lookup
 
 

--- a/qgreenland/util/luigi/tasks/main.py
+++ b/qgreenland/util/luigi/tasks/main.py
@@ -18,7 +18,7 @@ from qgreenland.util.layer import (
     get_layer_release_dir,
 )
 from qgreenland.util.luigi.target import temporary_path_dir
-from qgreenland.util.provenance import steps_to_provenance_text
+from qgreenland.util.provenance import write_provenance_file
 from qgreenland.util.qgis.metadata import build_layer_abstract
 from qgreenland.util.tree import leaf_lookup
 
@@ -162,12 +162,12 @@ class FinalizeTask(QgrLayerTask):
         with temporary_path_dir(self.output()) as temp_path:
             shutil.copy2(input_fp, temp_path / final_fn)
 
-            # Create layer provenance file. This is not an "AncillaryFile" job
-            # because we need one file per layer.
-            with open(temp_path / 'provenance.txt', 'w') as provenance_file:
-                provenance_file.write(
-                    steps_to_provenance_text(self.layer_cfg.steps),
-                )
+            # Create layer provenance and metadata files. These are not
+            # "AncillaryFile" jobs because we need one file per layer.
+            write_provenance_file(
+                layer_cfg=self.layer_cfg,
+                filepath=temp_path / 'provenance.txt',
+            )
 
             with open(temp_path / 'metadata.txt', 'w') as metadata_file:
                 metadata_file.write(

--- a/qgreenland/util/metadata.py
+++ b/qgreenland/util/metadata.py
@@ -1,83 +1,18 @@
 import datetime as dt
-import tempfile
 from pathlib import Path
-from xml.sax.saxutils import escape
-
-import qgis.core as qgc
 
 from qgreenland.constants.paths import FETCH_DATASETS_DIR
 from qgreenland.models.config.layer import Layer
 from qgreenland.util.layer import datasource_dirname
-from qgreenland.util.template import load_template
-
-
-def add_layer_metadata(map_layer: qgc.QgsMapLayer, layer_cfg: Layer) -> None:
-    """Add layer metadata.
-
-    Renders a jinja template to a temporary file location as a valid QGIS qmd
-    metadata file. This metadata then gets associated with the `map_layer` using
-    its `loadNamedMetadata` method. This metadata gets written to the project
-    file when the layer is added to the `project`.
-    """
-    qmd_template = load_template('metadata.jinja')
-
-    # Set the layer's tooltip
-    tooltip = _build_layer_tooltip(layer_cfg)
-    map_layer.setAbstract(tooltip)
-
-    # Render the qmd template.
-    abstract = escape(build_layer_metadata(layer_cfg))
-    layer_extent = map_layer.extent()
-    layer_crs = map_layer.crs()
-
-    if layer_cfg.steps:
-        provenance_list = [escape(step.provenance) for step in layer_cfg.steps]
-    else:
-        provenance_list = []
-
-    rendered_qmd = qmd_template.render(
-        provenance_list=provenance_list,
-        abstract=abstract,
-        title=layer_cfg.title,
-        crs_proj4_str=layer_crs.toProj4(),
-        crs_srsid=layer_crs.srsid(),
-        crs_postgres_srid=layer_crs.postgisSrid(),
-        crs_authid=layer_crs.authid(),
-        crs_description=layer_crs.description(),
-        crs_projection_acronym=layer_crs.projectionAcronym(),
-        crs_ellipsoid_acronym=layer_crs.ellipsoidAcronym(),
-        minx=layer_extent.xMinimum(),
-        miny=layer_extent.yMinimum(),
-        maxx=layer_extent.xMaximum(),
-        maxy=layer_extent.yMaximum(),
-    )
-
-    # Write the rendered tempalte to a temporary file
-    # location. `map_layer.loadNamedMetadata` expects a string URI corresponding
-    # to a file on disk.
-    with tempfile.NamedTemporaryFile('w') as temp_file:
-        temp_file.write(rendered_qmd)
-        temp_file.flush()
-        map_layer.loadNamedMetadata(temp_file.name)
-
-
-def _build_layer_tooltip(layer_cfg: Layer) -> str:
-    """Return a properly escaped layer tooltip text."""
-    tt = _build_layer_description(layer_cfg)
-    tt += (
-        '\n\n'
-        'Open Layer Properties and select the Metadata tab for more information.'
-    )
-    return escape(tt)
 
 
 def build_layer_metadata(layer_cfg: Layer) -> str:
     """Return layer metadata text.
-    
+
     Includes layer description, dataset description, and citation information.
     """
     # Include the layer description first.
-    abstract = _build_layer_description(layer_cfg)
+    abstract = build_layer_description(layer_cfg)
 
     # If the layer has a description, separate it from the abstract of the
     # original data source.
@@ -103,7 +38,7 @@ def write_metadata_file(*, layer_cfg: Layer, filepath: Path) -> None:
         )
 
 
-def _build_layer_description(layer_cfg: Layer) -> str:
+def build_layer_description(layer_cfg: Layer) -> str:
     """Return a string representing the layer's description."""
     layer_description = ''
 

--- a/qgreenland/util/provenance.py
+++ b/qgreenland/util/provenance.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+from qgreenland.models.config.layer import Layer
 from qgreenland.models.config.step import AnyStep
 
 
@@ -5,3 +8,17 @@ def steps_to_provenance_text(steps: list[AnyStep]) -> str:
     steps_as_text = [step.provenance for step in steps]
 
     return '\n\n'.join(steps_as_text)
+
+
+def write_provenance_file(*, layer_cfg: Layer, filepath: Path) -> None:
+    """Write layer provenance to a text file."""
+    # TODO: default message for layers with no processing steps?
+    txt_to_write = ''
+
+    if layer_cfg.steps:
+        txt_to_write = steps_to_provenance_text(layer_cfg.steps)
+
+    with open(filepath, 'w') as provenance_file:
+        provenance_file.write(
+            txt_to_write,
+        )

--- a/qgreenland/util/provenance.py
+++ b/qgreenland/util/provenance.py
@@ -12,7 +12,8 @@ def steps_to_provenance_text(steps: list[AnyStep]) -> str:
 
 def write_provenance_file(*, layer_cfg: Layer, filepath: Path) -> None:
     """Write layer provenance to a text file."""
-    # TODO: default message for layers with no processing steps?
+    # TODO: default message for layers with no processing steps? Just include a
+    # string that indicates where the data were fetched from?
     txt_to_write = ''
 
     if layer_cfg.steps:

--- a/qgreenland/util/qgis/layer.py
+++ b/qgreenland/util/qgis/layer.py
@@ -1,18 +1,82 @@
 import functools
+import tempfile
 from pathlib import Path
 from typing import Callable, Union
+from xml.sax.saxutils import escape
 
 import qgis.core as qgc
 from osgeo import gdal
 
 import qgreenland.exceptions as exc
 from qgreenland.models.config.asset import OnlineAsset
+from qgreenland.models.config.layer import Layer
 from qgreenland.util.layer import (
     get_layer_compile_filepath,
     vector_or_raster,
 )
-from qgreenland.util.qgis.metadata import add_layer_metadata
+from qgreenland.util.metadata import build_layer_description, build_layer_metadata
+from qgreenland.util.template import load_template
 from qgreenland.util.tree import LayerNode
+
+
+def _build_layer_tooltip(layer_cfg: Layer) -> str:
+    """Return a properly escaped layer tooltip text."""
+    tt = build_layer_description(layer_cfg)
+    tt += (
+        '\n\n'
+        'Open Layer Properties and select the Metadata tab for more information.'
+    )
+    return escape(tt)
+
+
+def add_layer_metadata(map_layer: qgc.QgsMapLayer, layer_cfg: Layer) -> None:
+    """Add layer metadata.
+
+    Renders a jinja template to a temporary file location as a valid QGIS qmd
+    metadata file. This metadata then gets associated with the `map_layer` using
+    its `loadNamedMetadata` method. This metadata gets written to the project
+    file when the layer is added to the `project`.
+    """
+    qmd_template = load_template('metadata.jinja')
+
+    # Set the layer's tooltip
+    tooltip = _build_layer_tooltip(layer_cfg)
+    map_layer.setAbstract(tooltip)
+
+    # Render the qmd template.
+    abstract = escape(build_layer_metadata(layer_cfg))
+    layer_extent = map_layer.extent()
+    layer_crs = map_layer.crs()
+
+    if layer_cfg.steps:
+        provenance_list = [escape(step.provenance) for step in layer_cfg.steps]
+    else:
+        provenance_list = []
+
+    rendered_qmd = qmd_template.render(
+        provenance_list=provenance_list,
+        abstract=abstract,
+        title=layer_cfg.title,
+        crs_proj4_str=layer_crs.toProj4(),
+        crs_srsid=layer_crs.srsid(),
+        crs_postgres_srid=layer_crs.postgisSrid(),
+        crs_authid=layer_crs.authid(),
+        crs_description=layer_crs.description(),
+        crs_projection_acronym=layer_crs.projectionAcronym(),
+        crs_ellipsoid_acronym=layer_crs.ellipsoidAcronym(),
+        minx=layer_extent.xMinimum(),
+        miny=layer_extent.yMinimum(),
+        maxx=layer_extent.xMaximum(),
+        maxy=layer_extent.yMaximum(),
+    )
+
+    # Write the rendered tempalte to a temporary file
+    # location. `map_layer.loadNamedMetadata` expects a string URI corresponding
+    # to a file on disk.
+    with tempfile.NamedTemporaryFile('w') as temp_file:
+        temp_file.write(rendered_qmd)
+        temp_file.flush()
+        map_layer.loadNamedMetadata(temp_file.name)
 
 
 def make_map_layer(layer_node: LayerNode) -> qgc.QgsMapLayer:

--- a/qgreenland/util/qgis/metadata.py
+++ b/qgreenland/util/qgis/metadata.py
@@ -26,7 +26,7 @@ def add_layer_metadata(map_layer: qgc.QgsMapLayer, layer_cfg: Layer) -> None:
     map_layer.setAbstract(tooltip)
 
     # Render the qmd template.
-    abstract = build_layer_abstract(layer_cfg)
+    abstract = escape(build_layer_abstract(layer_cfg))
     layer_extent = map_layer.extent()
     layer_crs = map_layer.crs()
 
@@ -72,7 +72,7 @@ def _build_layer_tooltip(layer_cfg: Layer) -> str:
 
 
 def build_layer_abstract(layer_cfg: Layer) -> str:
-    """Return a properly escaped layer abstract text."""
+    """Return a layer abstract text."""
     # Include the layer description first.
     abstract = _build_layer_description(layer_cfg)
 
@@ -89,7 +89,7 @@ def build_layer_abstract(layer_cfg: Layer) -> str:
     # Add the dataset's citation
     abstract += _build_dataset_citation(layer_cfg)
 
-    return escape(abstract)
+    return abstract
 
 
 def _build_layer_description(layer_cfg: Layer) -> str:

--- a/qgreenland/util/qgis/metadata.py
+++ b/qgreenland/util/qgis/metadata.py
@@ -26,7 +26,7 @@ def add_layer_metadata(map_layer: qgc.QgsMapLayer, layer_cfg: Layer) -> None:
     map_layer.setAbstract(tooltip)
 
     # Render the qmd template.
-    abstract = escape(build_layer_abstract(layer_cfg))
+    abstract = escape(build_layer_metadata(layer_cfg))
     layer_extent = map_layer.extent()
     layer_crs = map_layer.crs()
 
@@ -71,8 +71,11 @@ def _build_layer_tooltip(layer_cfg: Layer) -> str:
     return escape(tt)
 
 
-def build_layer_abstract(layer_cfg: Layer) -> str:
-    """Return a layer abstract text."""
+def build_layer_metadata(layer_cfg: Layer) -> str:
+    """Return layer metadata text.
+    
+    Includes layer description, dataset description, and citation information.
+    """
     # Include the layer description first.
     abstract = _build_layer_description(layer_cfg)
 
@@ -96,7 +99,7 @@ def write_metadata_file(*, layer_cfg: Layer, filepath: Path) -> None:
     """Write layer metadata to a text file."""
     with open(filepath, 'w') as metadata_file:
         metadata_file.write(
-            build_layer_abstract(layer_cfg),
+            build_layer_metadata(layer_cfg),
         )
 
 

--- a/qgreenland/util/qgis/metadata.py
+++ b/qgreenland/util/qgis/metadata.py
@@ -92,6 +92,14 @@ def build_layer_abstract(layer_cfg: Layer) -> str:
     return abstract
 
 
+def write_metadata_file(*, layer_cfg: Layer, filepath: Path) -> None:
+    """Write layer metadata to a text file."""
+    with open(filepath, 'w') as metadata_file:
+        metadata_file.write(
+            build_layer_abstract(layer_cfg),
+        )
+
+
 def _build_layer_description(layer_cfg: Layer) -> str:
     """Return a string representing the layer's description."""
     layer_description = ''


### PR DESCRIPTION
## Description

Export layer metadata (abstract info; description, citation, etc) to a `metadata.txt` file that sits alongside layer data in the final layer dir. This allows users who are browsing layers e.g., in their filesystem, to quickly access relevant information.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
