### PR TITLE
Replace usage of `OgrRemoteAsset` with `CommandAsset`

### DIFF
--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -1116,8 +1116,14 @@
     "nunagis_pop2019_municipalities": {
       "assets": {
         "only": {
-          "id": "only",
-          "query_url": "https://kort.nunagis.gl/server/rest/services/Hosted/POP2019_Municipalities/FeatureServer/0/query/?f=json&where=true&outFields=*&orderByFields=pop_municipality_2019_objectid+ASC"
+          "args": [
+            "ogr2ogr",
+            "-oo",
+            "FEATURE_SERVER_PAGING=YES",
+            "{output_dir}/fetched.geojson",
+            "https://kort.nunagis.gl/server/rest/services/Hosted/POP2019_Municipalities/FeatureServer/0/query/?f=json&where=true&outFields=*&orderByFields=pop_municipality_2019_objectid+ASC"
+          ],
+          "id": "only"
         }
       },
       "id": "nunagis_pop2019_municipalities",
@@ -1133,8 +1139,14 @@
     "nunagis_protected_areas": {
       "assets": {
         "only": {
-          "id": "only",
-          "query_url": "https://kort.nunagis.gl/server/rest/services/Hosted/Bird_important_areas/FeatureServer/0/query?f=json&where=true&outFields=*&orderByFields=fid0+ASC"
+          "args": [
+            "ogr2ogr",
+            "-oo",
+            "FEATURE_SERVER_PAGING=YES",
+            "{output_dir}/fetched.geojson",
+            "https://kort.nunagis.gl/server/rest/services/Hosted/Bird_important_areas/FeatureServer/0/query?f=json&where=true&outFields=*&orderByFields=fid0+ASC"
+          ],
+          "id": "only"
         }
       },
       "id": "nunagis_protected_areas",

--- a/qgreenland/config/datasets/nunagis_protected_areas.py
+++ b/qgreenland/config/datasets/nunagis_protected_areas.py
@@ -1,18 +1,14 @@
-from qgreenland.models.config.asset import CommandAsset
+from qgreenland.config.helpers.assets.ogr_remote import ogr_remote_asset
 from qgreenland.models.config.dataset import Dataset
 
 
 nunagis_protected_areas = Dataset(
     id='nunagis_protected_areas',
     assets=[
-        CommandAsset(
-            id='only',
-            args=[
-                'ogr2ogr',
-                '-oo', 'FEATURE_SERVER_PAGING=YES',
-                '{output_dir}/fetched.geojson',
-                'https://kort.nunagis.gl/server/rest/services/Hosted/Bird_important_areas/FeatureServer/0/query?f=json&where=true&outFields=*&orderByFields=fid0+ASC',
-            ],
+        ogr_remote_asset(
+            asset_id='only',
+            output_file='{output_dir}/fetched.geojson',
+            url='https://kort.nunagis.gl/server/rest/services/Hosted/Bird_important_areas/FeatureServer/0/query?f=json&where=true&outFields=*&orderByFields=fid0+ASC',
         ),
     ],
     metadata={

--- a/qgreenland/config/datasets/nunagis_protected_areas.py
+++ b/qgreenland/config/datasets/nunagis_protected_areas.py
@@ -1,13 +1,18 @@
-from qgreenland.models.config.asset import OgrRemoteAsset
+from qgreenland.models.config.asset import CommandAsset
 from qgreenland.models.config.dataset import Dataset
 
 
 nunagis_protected_areas = Dataset(
     id='nunagis_protected_areas',
     assets=[
-        OgrRemoteAsset(
+        CommandAsset(
             id='only',
-            query_url='https://kort.nunagis.gl/server/rest/services/Hosted/Bird_important_areas/FeatureServer/0/query?f=json&where=true&outFields=*&orderByFields=fid0+ASC',
+            args=[
+                'ogr2ogr',
+                '-oo', 'FEATURE_SERVER_PAGING=YES',
+                '{output_dir}/fetched.geojson',
+                'https://kort.nunagis.gl/server/rest/services/Hosted/Bird_important_areas/FeatureServer/0/query?f=json&where=true&outFields=*&orderByFields=fid0+ASC',
+            ],
         ),
     ],
     metadata={

--- a/qgreenland/config/datasets/political_boundaries.py
+++ b/qgreenland/config/datasets/political_boundaries.py
@@ -1,6 +1,6 @@
 from qgreenland.models.config.asset import (
+    CommandAsset,
     HttpAsset,
-    OgrRemoteAsset,
 )
 from qgreenland.models.config.dataset import Dataset
 
@@ -8,9 +8,14 @@ from qgreenland.models.config.dataset import Dataset
 nunagis_pop2019_municipalities = Dataset(
     id='nunagis_pop2019_municipalities',
     assets=[
-        OgrRemoteAsset(
+        CommandAsset(
             id='only',
-            query_url='https://kort.nunagis.gl/server/rest/services/Hosted/POP2019_Municipalities/FeatureServer/0/query/?f=json&where=true&outFields=*&orderByFields=pop_municipality_2019_objectid+ASC',
+            args=[
+                'ogr2ogr',
+                '-oo', 'FEATURE_SERVER_PAGING=YES',
+                '{output_dir}/fetched.geojson',
+                'https://kort.nunagis.gl/server/rest/services/Hosted/POP2019_Municipalities/FeatureServer/0/query/?f=json&where=true&outFields=*&orderByFields=pop_municipality_2019_objectid+ASC',
+            ],
         ),
     ],
     metadata={

--- a/qgreenland/config/datasets/political_boundaries.py
+++ b/qgreenland/config/datasets/political_boundaries.py
@@ -1,21 +1,15 @@
-from qgreenland.models.config.asset import (
-    CommandAsset,
-    HttpAsset,
-)
+from qgreenland.config.helpers.assets.ogr_remote import ogr_remote_asset
+from qgreenland.models.config.asset import HttpAsset
 from qgreenland.models.config.dataset import Dataset
 
 
 nunagis_pop2019_municipalities = Dataset(
     id='nunagis_pop2019_municipalities',
     assets=[
-        CommandAsset(
-            id='only',
-            args=[
-                'ogr2ogr',
-                '-oo', 'FEATURE_SERVER_PAGING=YES',
-                '{output_dir}/fetched.geojson',
-                'https://kort.nunagis.gl/server/rest/services/Hosted/POP2019_Municipalities/FeatureServer/0/query/?f=json&where=true&outFields=*&orderByFields=pop_municipality_2019_objectid+ASC',
-            ],
+        ogr_remote_asset(
+            asset_id='only',
+            output_file='{output_dir}/fetched.geojson',
+            url='https://kort.nunagis.gl/server/rest/services/Hosted/POP2019_Municipalities/FeatureServer/0/query/?f=json&where=true&outFields=*&orderByFields=pop_municipality_2019_objectid+ASC',
         ),
     ],
     metadata={

--- a/qgreenland/config/helpers/assets/ogr_remote.py
+++ b/qgreenland/config/helpers/assets/ogr_remote.py
@@ -1,0 +1,18 @@
+from qgreenland.models.config.asset import CommandAsset
+
+
+def ogr_remote_asset(
+    *,
+    asset_id: str,
+    url: str,
+    output_file: str,
+) -> CommandAsset:
+    return CommandAsset(
+        id=asset_id,
+        args=[
+            'ogr2ogr',
+            '-oo', 'FEATURE_SERVER_PAGING=YES',
+            output_file,
+            url,
+        ],
+    )

--- a/qgreenland/models/config/asset.py
+++ b/qgreenland/models/config/asset.py
@@ -77,12 +77,6 @@ class CommandAsset(DatasetAsset):
     args: list[EvalStr]
 
 
-class OgrRemoteAsset(DatasetAsset):
-    """Assets that are fetched via `ogr2ogr` from the given query_url."""
-
-    query_url: AnyUrl
-
-
 AnyAsset = Union[
     CmrAsset,
     CommandAsset,
@@ -90,5 +84,4 @@ AnyAsset = Union[
     ManualAsset,
     OnlineAsset,
     RepositoryAsset,
-    OgrRemoteAsset,
 ]

--- a/qgreenland/util/luigi/__init__.py
+++ b/qgreenland/util/luigi/__init__.py
@@ -9,7 +9,6 @@ from qgreenland.models.config.asset import (
     CommandAsset,
     HttpAsset,
     ManualAsset,
-    OgrRemoteAsset,
     OnlineAsset,
     RepositoryAsset,
 )
@@ -21,7 +20,6 @@ from qgreenland.util.luigi.tasks.fetch import (
     FetchDataFiles,
     FetchDataWithCommand,
     FetchLocalDataFiles,
-    FetchOgrRemoteData,
     FetchTask,
 )
 from qgreenland.util.luigi.tasks.main import ChainableTask, FinalizeTask
@@ -35,7 +33,6 @@ ASSET_TYPE_TASKS: dict[Type[AnyAsset], Type[FetchTask]] = {
     # TODO: rename `FetchLocalDataFiles`, split in two!
     ManualAsset: FetchLocalDataFiles,
     RepositoryAsset: FetchLocalDataFiles,
-    OgrRemoteAsset: FetchOgrRemoteData,
 }
 
 

--- a/qgreenland/util/luigi/tasks/fetch.py
+++ b/qgreenland/util/luigi/tasks/fetch.py
@@ -141,25 +141,3 @@ class FetchDataWithCommand(FetchTask):
                     output_dir=temp_path,
                 ),
             )
-
-
-class FetchOgrRemoteData(FetchTask):
-    def output(self):
-        return luigi.LocalTarget(
-            FETCH_DATASETS_DIR / self.output_name,
-            format=luigi.format.Nop,
-        )
-
-    def run(self):
-        with temporary_path_dir(self.output()) as temp_path:
-            url = self.asset_cfg.query_url
-
-            ofile = temp_path / 'fetched.geojson'
-            run_qgr_command(
-                [
-                    'ogr2ogr',
-                    '-oo', 'FEATURE_SERVER_PAGING=YES',
-                    str(ofile),
-                    f'"{url}"',
-                ],
-            )


### PR DESCRIPTION
## Description

Replace usage of `OgrRemoteAsset` with `CommandAsset`


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
