### PR TITLE
Fixup JPEG compression artifacts for the background layer 

### DIFF
--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -25303,6 +25303,60 @@
                 },
                 {
                   "args": [
+                    "cp",
+                    "{input_dir}/warped_and_cut.tif",
+                    "{output_dir}/input.tif",
+                    "&&",
+                    "gdal_calc.py",
+                    "--calc=\"numpy.invert(numpy.isnan(A)).astype(int)\"",
+                    "--outfile={output_dir}/mask.tif",
+                    "-A",
+                    "{output_dir}/input.tif",
+                    "--A_band=1"
+                  ],
+                  "type": "command"
+                },
+                {
+                  "args": [
+                    "cp",
+                    "{input_dir}/*",
+                    "{output_dir}/",
+                    "&&",
+                    "gdal_translate",
+                    "-b",
+                    "1",
+                    "{input_dir}/input.tif",
+                    "{output_dir}/b1.tif",
+                    "&&",
+                    "gdal_translate",
+                    "-b",
+                    "2",
+                    "{input_dir}/input.tif",
+                    "{output_dir}/b2.tif",
+                    "&&",
+                    "gdal_translate",
+                    "-b",
+                    "3",
+                    "{input_dir}/input.tif",
+                    "{output_dir}/b3.tif"
+                  ],
+                  "type": "command"
+                },
+                {
+                  "args": [
+                    "gdal_merge.py",
+                    "-o",
+                    "{output_dir}/merged.tif",
+                    "-separate",
+                    "{input_dir}/b1.tif",
+                    "{input_dir}/b2.tif",
+                    "{input_dir}/b3.tif",
+                    "{input_dir}/mask.tif"
+                  ],
+                  "type": "command"
+                },
+                {
+                  "args": [
                     "gdal_translate",
                     "-co",
                     "TILED=YES",
@@ -25312,7 +25366,18 @@
                     "JPEG_QUALITY=90",
                     "-co",
                     "PHOTOMETRIC=YCBCR",
-                    "{input_dir}/warped_and_cut.tif",
+                    "-b",
+                    "1",
+                    "-b",
+                    "2",
+                    "-b",
+                    "3",
+                    "-mask",
+                    "4",
+                    "--config",
+                    "GDAL_TIFF_INTERNAL_MASK",
+                    "YES",
+                    "{input_dir}/merged.tif",
                     "{output_dir}/compressed.tif"
                   ],
                   "type": "command"

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -25347,6 +25347,8 @@
                     "gdal_merge.py",
                     "-o",
                     "{output_dir}/merged.tif",
+                    "-co",
+                    "COMPRESS=DEFLATE",
                     "-separate",
                     "{input_dir}/b1.tif",
                     "{input_dir}/b2.tif",

--- a/qgreenland/config/layers/Basemaps/background.py
+++ b/qgreenland/config/layers/Basemaps/background.py
@@ -11,7 +11,7 @@ def _separate_band(idx) -> list[str]:
         'gdal_translate',
         '-b', str(idx),
         '{input_dir}/input.tif',
-        '{output_dir}/' + f'b{idx}.tif'
+        '{output_dir}/' + f'b{idx}.tif',
     ]
 
 

--- a/qgreenland/config/layers/Basemaps/background.py
+++ b/qgreenland/config/layers/Basemaps/background.py
@@ -66,13 +66,12 @@ background = Layer(
                 *_separate_band(3),
             ],
         ),
-        # TODO: consider DEFLATE compression for this step. Output is about 2
-        # GB.
         CommandStep(
             id='merge_bands',
             args=[
                 'gdal_merge.py',
                 '-o', '{output_dir}/merged.tif',
+                '-co', 'COMPRESS=DEFLATE',
                 '-separate',
                 '{input_dir}/b1.tif',
                 '{input_dir}/b2.tif',

--- a/qgreenland/config/layers/Basemaps/background.py
+++ b/qgreenland/config/layers/Basemaps/background.py
@@ -3,6 +3,16 @@ from qgreenland.config.helpers.steps.compress_and_add_overviews import compress_
 from qgreenland.config.helpers.steps.decompress import decompress_step
 from qgreenland.config.helpers.steps.warp_and_cut import warp_and_cut
 from qgreenland.models.config.layer import Layer, LayerInput
+from qgreenland.models.config.step import CommandStep
+
+
+def _separate_band(idx) -> list[str]:
+    return [
+        'gdal_translate',
+        '-b', str(idx),
+        '{input_dir}/input.tif',
+        '{output_dir}/' + f'b{idx}.tif'
+    ]
 
 
 background = Layer(
@@ -32,13 +42,54 @@ background = Layer(
             ],
             cut_file='{assets_dir}/latitude_shape_40_degrees.geojson',
         ),
+        CommandStep(
+            id='create_mask',
+            args=[
+                'cp', '{input_dir}/warped_and_cut.tif', '{output_dir}/input.tif',
+                '&&',
+                'gdal_calc.py',
+                '--calc="numpy.invert(numpy.isnan(A)).astype(int)"',
+                '--outfile={output_dir}/mask.tif',
+                '-A', '{output_dir}/input.tif',
+                '--A_band=1',
+            ],
+        ),
+        CommandStep(
+            id='separate_bands',
+            args=[
+                'cp', '{input_dir}/*', '{output_dir}/',
+                '&&',
+                *_separate_band(1),
+                '&&',
+                *_separate_band(2),
+                '&&',
+                *_separate_band(3),
+            ],
+        ),
+        # TODO: consider DEFLATE compression for this step. Output is about 2
+        # GB.
+        CommandStep(
+            id='merge_bands',
+            args=[
+                'gdal_merge.py',
+                '-o', '{output_dir}/merged.tif',
+                '-separate',
+                '{input_dir}/b1.tif',
+                '{input_dir}/b2.tif',
+                '{input_dir}/b3.tif',
+                '{input_dir}/mask.tif',
+            ],
+        ),
         *compress_and_add_overviews(
-            input_file='{input_dir}/warped_and_cut.tif',
+            input_file='{input_dir}/merged.tif',
             output_file='{output_dir}/overviews.tif',
             compress_type='JPEG',
             compress_args=[
                 '-co', 'JPEG_QUALITY=90',
                 '-co', 'PHOTOMETRIC=YCBCR',
+                '-b', '1', '-b', '2', '-b', '3',
+                '-mask', '4',
+                '--config', 'GDAL_TIFF_INTERNAL_MASK', 'YES',
             ],
         ),
     ],

--- a/qgreenland/config/layers/Basemaps/background.py
+++ b/qgreenland/config/layers/Basemaps/background.py
@@ -44,8 +44,8 @@ background = Layer(
         ),
         # Because the background image is large, we use JPEG compression
         # (`compress_and_add_overviews` step below). To do so without JPEG
-        # artifacts around the edges of the image (appears as black pixels
-        # around the outside edges of the image), a mask band can be
+        # artifacts around the curved clip boundary the image (appears as black
+        # pixels around the outside edges of the image), a mask band can be
         # used. This step creates the mask file that will be added as a fourth
         # band to the RGB background image.
         CommandStep(


### PR DESCRIPTION
## Description

Fixup JPEG compression artifacts for the background layer by using a mask band.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
