### PR TITLE
Use `extlinks` to DRY out external refs to github

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'myst_parser',
     'sphinx.ext.linkcode',
     'sphinx.ext.autodoc',
+    'sphinx.ext.extlinks',
     # TODO: What does this do?
     # 'sphinx_autodoc_typehints',  # MUST be after 'sphinx.ext.autodoc'.
     'sphinxcontrib.autodoc_pydantic',
@@ -105,3 +106,9 @@ autodoc_pydantic_model_show_validator_summary = False
 
 # Hide redundant field summary
 autodoc_pydantic_model_show_field_summary = False
+
+
+# -- Options for extlinks ------------------------------------------------------
+extlinks = {
+    'github': ('https://github.com/nsidc/qgreenland/tree/main/%s', 'GitHub: %s'),
+}

--- a/doc/reference/architecture/configuration.md
+++ b/doc/reference/architecture/configuration.md
@@ -35,7 +35,7 @@ Fix links to source code. Consider using this? https://www.sphinx-doc.org/en/mas
 ```
 
 
-[project.py](/qgreenland/config/project.py) defines the project `crs` (EPSG) and
+{github}`project.py <qgreenland/config/project.py>` defines the project `crs` (EPSG) and
 any `boundaries` that will be used to clip data for this project.
 
 
@@ -44,7 +44,7 @@ any `boundaries` that will be used to clip data for this project.
 Dataset configurations define a unique `id`, `metadata`, and a list of
 `assets`.
 
-[Example](/qgreenland/config/datasets/background.py)
+{github}`Example <qgreenland/config/datasets/background.py>`
 
 
 ### Assets
@@ -67,9 +67,12 @@ There are various types of assets. Some useful ones are:
   scientist over e-mail and is not hosted anywhere. We prefer to avoid or
   eventually fully eliminate the use of data in this category.
 
-You can find the full set of available asset types
-[here](/qgreenland/models/config/asset.py).
+```{admonition} TODO
 
+Link to API docs?
+```
+You can find the full set of available asset types
+{github}`here</qgreenland/models/config/asset.py>`.
 
 ## Layers and layer groups config
 
@@ -94,7 +97,7 @@ Layers are created in a series of `steps`. The final result of the `steps` must
 be a GeoTIFF (`.tif` file) for raster layers, and a GeoPackage (`.gpkg`) for
 vector layers.
 
-Each step is a [command](/qgreenland/models/config/step.py) (e.g. `gdalwarp` or
+Each step is a {github}`command </qgreenland/models/config/step.py>` (e.g. `gdalwarp` or
 `ogr2ogr`) run against the output of the previous step.  The first step acts on
 the chosen `input.asset`.
 
@@ -115,13 +118,13 @@ runtime variables are legal:
 Each layer group can optionally have a `__settings__.py` file inside its
 directory which determines settings for only that group. If the file is
 omitted, defaults are used (see
-[here](/qgreenland/models/config/layer_group.py) for default values).
+{github}`here </qgreenland/models/config/layer_group.py>` for default values).
 
 This file is most commonly used for specifying the order in which the layer
 group's contents will be displayed in QGIS. If `order` is not specified,
 contents are displayed alphabetically with groups first.
 
-An [example](/qgreenland/config/layers/Reference/__settings__.py) settings file
+An {github}`example </qgreenland/config/layers/Reference/__settings__.py>` settings file
 shows that layers are represented with a leading `:` to differentiate layers
 from groups in the same list.
 


### PR DESCRIPTION
## Description

Use `extlinks` to DRY out external refs to github


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
