### PR TITLE
Fix paragraph text validator to handle empty strings

### DIFF
--- a/qgreenland/util/model_validators.py
+++ b/qgreenland/util/model_validators.py
@@ -3,11 +3,17 @@ from typing import Any, Callable
 from pydantic import validator
 
 
-def reusable_validator(name: str, validation_func: Callable[..., Any]) -> classmethod:
+def reusable_validator(
+    name: str,
+    validation_func: Callable[..., Any],
+) -> classmethod:
     return validator(name, allow_reuse=True)(validation_func)
 
 
 def validate_paragraph_text(text: str):
+    if not text:
+        raise ValueError('Paragraph text must not be empty.')
+
     if not text[0].isupper():
         raise ValueError('Paragraph text must begin with an upper-case letter.')
 


### PR DESCRIPTION
## Description

Fix paragraph text validator to handle empty strings.

It still doesn't tell you which file or which line the error came from, but that's a separate problem.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
