### PR TITLE
PDF documentation improvements

### DIFF
--- a/doc/acknowledgements.md
+++ b/doc/acknowledgements.md
@@ -35,8 +35,6 @@ projects. This is not an exhaustive list -- if your project is listed in our
 * [cmocean](https://github.com/matplotlib/cmocean)
 * [Python](https://www.python.org)
 * [Luigi](https://github.com/spotify/luigi)
-* [Rasterio](https://github.com/mapbox/rasterio)
-* [GeoPandas](https://geopandas.org/)
 * [GDAL](https://gdal.org)
 * [Docker](https://www.docker.com/)
 

--- a/doc/citing.md
+++ b/doc/citing.md
@@ -1,0 +1,16 @@
+# Citing QGreenland
+
+We request that QGreenland be cited or acknowledged when publishing a
+QGreenland-made image or map.
+
+
+## Citation
+
+    Moon, T., M. Fisher, L. Harden, & T. Stafford (2021). QGreenland
+    (v1.0.1) [software]. Available from https://qgreenland.org.
+    https://doi.org/10.5281/zenodo.4558266.
+
+
+## Acknowledgement
+
+    We acknowledge the National Snow and Ice Data Center QGreenland package.

--- a/doc/citing.md
+++ b/doc/citing.md
@@ -6,11 +6,11 @@ QGreenland-made image or map.
 
 ## Citation
 
-    Moon, T., M. Fisher, L. Harden, & T. Stafford (2021). QGreenland
-    (v1.0.1) [software]. Available from https://qgreenland.org.
-    https://doi.org/10.5281/zenodo.4558266.
+> Moon, T., M. Fisher, L. Harden, & T. Stafford (2021). QGreenland (v1.0.1)
+> [software]. Available from https://qgreenland.org.
+> https://doi.org/10.5281/zenodo.4558266.
 
 
 ## Acknowledgement
 
-    We acknowledge the National Snow and Ice Data Center QGreenland package.
+> We acknowledge the National Snow and Ice Data Center QGreenland package.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,7 +65,39 @@ html_theme = 'sphinx_rtd_theme'
 html_static_path = []
 
 
+# -- Options for LaTeX output --------------------------------------------------
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title, author, document class
+# [howto|manual], ???).
+latex_documents = [(
+    # Input file
+    'index',
+    # Output file
+    'qgreenland.tex',
+    # Title
+    'QGreenland Documentation',
+    # Authors
+    author,
+    'manual',
+    False,
+)]
+
+latex_logo = '../qgreenland/ancillary/images/qgreenland.png'
+
+latex_elements = {
+    # remove blank pages
+    'classoptions': ',openany,oneside',
+    # Set pdf-wide table-of-contents depth
+    'preamble': r'''
+      \usepackage{hyperref}
+      \setcounter{tocdepth}{3}
+    '''
+}
+
+
 # -- Options for linkcode behavior ---------------------------------------------
+
 def linkcode_resolve(domain, info):
     # Domain could be `py`, `c`, `cpp`, `javascript`, but this is a Python
     # project.
@@ -82,7 +114,9 @@ def linkcode_resolve(domain, info):
 # `qgreenland.models.config.asset.CmrAsset`
 add_module_names = True
 
+
 # -- Options for autodoc output ------------------------------------------------
+
 autodoc_default_options = {
     # Document all public members by default.
     'members': None,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -85,6 +85,10 @@ latex_documents = [(
 
 latex_logo = '../qgreenland/ancillary/images/qgreenland.png'
 
+latex_show_urls = 'footnote'
+
+latex_show_pagerefs = True
+
 latex_elements = {
     # remove blank pages
     'classoptions': ',openany,oneside',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -151,6 +151,10 @@ autodoc_pydantic_model_show_validator_summary = False
 # Hide redundant field summary
 autodoc_pydantic_model_show_field_summary = False
 
+# Don't show collapsible JSONSchema model. It's too big for the PDF output. Is
+# there a way to enable it for HTML only and disable for PDF?
+autodoc_pydantic_model_show_json = False
+
 # Don't warn when a field is not serializable
 autodoc_pydantic_model_show_json_error_strategy = 'coerce'
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,39 +3,67 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-.. toctree::
-    :name: Main TOC
-    :hidden:
-    :maxdepth: 1
 
+========================
+QGreenland Documentation
+========================
+
+
+.. raw:: latex
+
+    \part{Introduction}
+
+
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+
+    what_is_qgr.md
+    citing.md
     acknowledgements.md
+
+
+.. raw:: latex
+
+    \part{Tutorials}
+
 
 .. toctree::
     :name: Tutorials
-    :hidden:
     :caption: Tutorials
     :maxdepth: 1
     :glob:
+    :hidden:
 
     tutorials/*
+
+
+.. raw:: latex
+
+    \part{How-to}
+
 
 .. toctree::
     :name: How-to
     :caption: How-to
-    :hidden:
     :maxdepth: 1
-    :glob:
+    :hidden:
 
     contributor-how-to/index
     user-how-to/index
 
 
+.. raw:: latex
+
+    \part{Reference}
+
+
 .. toctree::
     :name: Reference
-    :hidden:
     :caption: Reference
     :maxdepth: 1
     :glob:
+    :hidden:
 
     reference/glossary/index
     reference/architecture/index
@@ -44,59 +72,30 @@
     reference/*
 
 
+.. raw:: latex
+
+    \part{Discussion topics}
+
+
 .. toctree::
     :name: Discussion topics
-    :hidden:
     :caption: Discussion topics
     :maxdepth: 1
     :glob:
+    :hidden:
 
     discussion/*
 
 
-What is QGreenland?
-===================
+.. raw:: latex
 
-.. image:: _images/qgreenland-examples.jpg
-    :alt: QGreenland examples
-
-QGreenland is a free and open-source Greenland-focused GIS environment for data
-analysis and viewing, powered by `QGIS <https://qgis.org>`_. QGreenland is
-delivered in two ways:
-
-1. as a large Zip package containing a core set of data curated to serve the
-   majority of users; and
-
-2. as a QGIS plugin for downloading a custom set of data, including data which
-   isn't part of the Zip package (for example, due to filesize constraints).
+    \part{Appendix}
 
 
-What QGreenland *is not*
-------------------------
+.. only:: builder_html
 
-* The QGreenland project is not a data-production project. While we do
-  process existing data, it is only to enable efficient and effective viewing
-  in the QGreenland QGIS environment.
+    .. include:: what_is_qgr.md
+        :parser: myst_parser.sphinx_
 
-* QGreenland is not a navigational aid.
-
-
-Citing QGreenland
-=================
-
-We request that QGreenland be cited or acknowledged when publishing a
-QGreenland-made image or map.
-
-
-Citation
---------
-
-    Moon, T., M. Fisher, L. Harden, & T. Stafford (2021). QGreenland
-    (v1.0.1) [software]. Available from https://qgreenland.org.
-    https://doi.org/10.5281/zenodo.4558266.
-
-
-Acknowledgement
----------------
-
-    We acknowledge the National Snow and Ice Data Center QGreenland package.
+    .. include:: citing.md
+        :parser: myst_parser.sphinx_

--- a/doc/what_is_qgr.md
+++ b/doc/what_is_qgr.md
@@ -3,7 +3,7 @@
 ![Qgreenland examples](_images/qgreenland-examples.jpg)
 
 QGreenland is a free and open-source Greenland-focused GIS environment for data
-analysis and viewing, powered by [QGIS](https://qgis.org>). QGreenland is
+analysis and viewing, powered by [QGIS](https://qgis.org). QGreenland is
 delivered in two ways:
 
 1. as a large Zip package containing a core set of data curated to serve the

--- a/doc/what_is_qgr.md
+++ b/doc/what_is_qgr.md
@@ -1,0 +1,22 @@
+# What is QGreenland?
+
+![Qgreenland examples](_images/qgreenland-examples.jpg)
+
+QGreenland is a free and open-source Greenland-focused GIS environment for data
+analysis and viewing, powered by [QGIS](https://qgis.org>). QGreenland is
+delivered in two ways:
+
+1. as a large Zip package containing a core set of data curated to serve the
+   majority of users; and
+
+2. as a QGIS plugin for downloading a custom set of data, including data which
+   isn't part of the Zip package (for example, due to filesize constraints).
+
+
+## What QGreenland *is not*
+
+* The QGreenland project is not a data-production project. While we do
+  process existing data, it is only to enable efficient and effective viewing
+  in the QGreenland QGIS environment.
+
+* QGreenland is not a navigational aid.


### PR DESCRIPTION
## Description

- Clean up OBE acknowledgements
- Improve PDF output
    - Nest all `toctree`s under a common header. This is important or the first chapter header gets swallowed and treated as the header for the whole document.
    - Conditional content for HTML site only
    - Add "parts" to the LaTeX / HTML output
    - Tweak LaTeX rendering options: enable pagerefs, URL footers, remove blank pages
- Remove JSON schema output from all doc outputs. It was overwhelming in PDF form, and I don't know how to only display them in HTML cleanly.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
