### PR TITLE
Temporarily remove online layers from manifset.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Added new QGreenland Custom (QGIS plugin) layer: "Geophysics/World Digital
   Magnetic Anomaly Map".
+- Remove online layers from the `QGreenland Custom` QGIS plugin manifest. Once
+  support for online layers is added to the plugin, online layers will be
+  re-added to the manifest file.
 
 # v2.0.0beta1 (2021-12-21)
 

--- a/qgreenland/test/util/config/test_config_export.py
+++ b/qgreenland/test/util/config/test_config_export.py
@@ -51,21 +51,25 @@ https://nsidc.org""",
     assert len(actual['qgr_version']) >= 6
     del actual['qgr_version']
 
-    online_asset = {
-        'type': 'online',
-        **full_cfg.layers['example_online'].input.asset.dict(
-            include={'provider', 'url'},
-        ),
-    }
+    # For now, do not include online layers in the layer manifest. The
+    # `QGreenland Custom` QGIS Plugin does not currently support online
+    # layers. Once online layers are supported in the plugin, this commented out
+    # `online_asset` can be re-added:
+    # online_asset = {
+    #     'type': 'online',
+    #     **full_cfg.layers['example_online'].input.asset.dict(
+    #         include={'provider', 'url'},
+    #     ),
+    # }
     expected = {
         'version': 'v0.1.0',
         'layers': [
-            {
-                'id': 'example_online',
-                'title': 'Example online',
-                'assets': [online_asset],
-                **common,
-            },
+            # {
+            #     'id': 'example_online',
+            #     'title': 'Example online',
+            #     'assets': [online_asset],
+            #     **common,
+            # },
             {
                 'id': 'example_raster',
                 'title': 'Example raster',

--- a/qgreenland/util/config/export.py
+++ b/qgreenland/util/config/export.py
@@ -49,14 +49,22 @@ def export_config_manifest(
     manifest = {
         'version': manifest_spec_version,
         'qgr_version': get_build_version(),
-        'layers': [{
-            # ID first for readability
-            'id': layer_node.layer_cfg.id,
-            **layer_node.layer_cfg.dict(include={'title', 'description', 'tags'}),
-            'hierarchy': layer_node.group_name_path,
-            'layer_details': build_layer_metadata(layer_node.layer_cfg),
-            'assets': _layer_manifest_final_assets(layer_node),
-        } for layer_node in cfg.layer_tree.leaves],
+        'layers': [
+            {
+                # ID first for readability
+                'id': layer_node.layer_cfg.id,
+                **layer_node.layer_cfg.dict(include={'title', 'description', 'tags'}),
+                'hierarchy': layer_node.group_name_path,
+                'layer_details': build_layer_metadata(layer_node.layer_cfg),
+                'assets': _layer_manifest_final_assets(layer_node),
+            }
+            for layer_node in cfg.layer_tree.leaves
+            # For now, do not include online layers in the layer manifest. The
+            # `QGreenland Custom` QGIS Plugin does not currently support online
+            # layers. Once online layers are supported in the plugin, this `if`
+            # statement can be removed.
+            if not isinstance(layer_node.layer_cfg.input.asset, OnlineAsset)
+        ],
     }
 
     with open(output_path, 'w') as ofile:


### PR DESCRIPTION
## Description

Remove online layers from plugin manifest.json file. Online layers will be re-added to the manifest once the plugin has support for online layers


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
