### PR TITLE
fix max_concentration_year variable

### DIFF
--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -1599,13 +1599,6 @@
           ],
           "verify_tls": true
         },
-        "maximum_concentration_2022": {
-          "id": "maximum_concentration_2022",
-          "urls": [
-            "ftp://sidads.colorado.edu/DATASETS/NOAA/G02135/north/monthly/geotiff/03_Mar/N_202203_concentration_v3.0.tif"
-          ],
-          "verify_tls": true
-        },
         "median_extent_line_01": {
           "id": "median_extent_line_01",
           "urls": [
@@ -23972,95 +23965,6 @@
                       "title": "March 2021"
                     },
                     "name": "seaice_maximum_concentration_2021"
-                  },
-                  {
-                    "layer_cfg": {
-                      "description": "Monthly average of sea ice concentration as a percentage (e.g., 99.9 =\n99.9%). Values under 15% are considered to be open water.",
-                      "id": "seaice_maximum_concentration_2022",
-                      "in_package": true,
-                      "input": {
-                        "asset": {
-                          "id": "maximum_concentration_2022"
-                        },
-                        "dataset": {
-                          "id": "seaice_index"
-                        }
-                      },
-                      "show": false,
-                      "steps": [
-                        {
-                          "args": [
-                            "gdal_calc.py",
-                            "--calc",
-                            "'A / 10.0'",
-                            "-A",
-                            "{input_dir}/*.tif",
-                            "--outfile={output_dir}/downscaled.tif"
-                          ],
-                          "type": "command"
-                        },
-                        {
-                          "args": [
-                            "gdalwarp",
-                            "-t_srs",
-                            "EPSG:3413",
-                            "-r",
-                            "bilinear",
-                            "{input_dir}/downscaled.tif",
-                            "{output_dir}/warped.tif"
-                          ],
-                          "type": "command"
-                        },
-                        {
-                          "args": [
-                            "gdalwarp",
-                            "-cutline",
-                            "{assets_dir}/latitude_shape_40_degrees.geojson",
-                            "-crop_to_cutline",
-                            "-co",
-                            "COMPRESS=DEFLATE",
-                            "{input_dir}/warped.tif",
-                            "{output_dir}/warped_and_cut.tif"
-                          ],
-                          "type": "command"
-                        },
-                        {
-                          "args": [
-                            "gdal_translate",
-                            "-co",
-                            "TILED=YES",
-                            "-co",
-                            "COMPRESS=DEFLATE",
-                            "-co",
-                            "PREDICTOR=2",
-                            "{input_dir}/warped_and_cut.tif",
-                            "{output_dir}/compressed.tif"
-                          ],
-                          "type": "command"
-                        },
-                        {
-                          "args": [
-                            "cp",
-                            "{input_dir}/compressed.tif",
-                            "{output_dir}/overviews.tif",
-                            "&&",
-                            "gdaladdo",
-                            "-r",
-                            "average",
-                            "{output_dir}/overviews.tif",
-                            "2",
-                            "4",
-                            "8",
-                            "16"
-                          ],
-                          "type": "command"
-                        }
-                      ],
-                      "style": "sea_ice_concentration",
-                      "tags": [],
-                      "title": "March 2022"
-                    },
-                    "name": "seaice_maximum_concentration_2022"
                   }
                 ],
                 "name": "Feb or March (max monthly extent)",

--- a/qgreenland/config/helpers/layers/sea_ice_concentration.py
+++ b/qgreenland/config/helpers/layers/sea_ice_concentration.py
@@ -4,7 +4,7 @@ from qgreenland.models.config.asset import HttpAsset
 
 
 CONCENTRATION_START_YEAR = 2010
-MAX_CONCENTRATION_YEARS = range(CONCENTRATION_START_YEAR, 2022 + 1)
+MAX_CONCENTRATION_YEARS = range(CONCENTRATION_START_YEAR, 2021 + 1)
 MIN_CONCENTRATION_YEARS = range(CONCENTRATION_START_YEAR, 2021 + 1)
 CONCENTRATION_DESCRIPTION = (
     """Monthly average of sea ice concentration as a percentage (e.g., 99.9 =


### PR DESCRIPTION
## Description

fix max_concentration_year variable since March 2022 data is not available

## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [ ] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [ ] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [ ] CHANGELOG.md updated
- [ ] Documentation updated if needed
- [ ] New unit tests if needed
