### PR TITLE
Splitup reference section into 'user' and 'contributor' sections.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -59,17 +59,16 @@ QGreenland Documentation
     \part{Reference}
 
 
-.. only:: latex
+.. toctree::
+    :name: User_Reference
+    :caption: User Reference
+    :maxdepth: 1
+    :hidden:
 
-  .. toctree::
-      :name: User_Reference
-      :caption: User Reference
-      :maxdepth: 1
-      :hidden:
-  
-      reference/glossary/index
-      reference/data-compatibility-guide.md
-      reference/online-resources.md
+    reference/glossary/index
+    reference/data-compatibility-guide.md
+    reference/online-resources.md
+
 
 .. only:: not latex
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -59,20 +59,30 @@ QGreenland Documentation
     \part{Reference}
 
 
-.. toctree::
-    :name: Reference
-    :caption: Reference
-    :maxdepth: 1
-    :glob:
-    :hidden:
+.. only:: latex
 
-    reference/glossary/index
-    reference/data-compatibility-guide.md
-    reference/online-resources.md
-    reference/architecture/index
-    reference/api/index
-    reference/cli/index
-    reference/*
+  .. toctree::
+      :name: User_Reference
+      :caption: User Reference
+      :maxdepth: 1
+      :hidden:
+  
+      reference/glossary/index
+      reference/data-compatibility-guide.md
+      reference/online-resources.md
+
+.. only:: not latex
+
+  .. toctree::
+      :name: Contributor_Reference
+      :caption: Contributor Reference
+      :maxdepth: 1
+      :hidden:
+  
+      reference/architecture/index
+      reference/api/index
+      reference/cli/index
+      reference/style-guide.md
 
 
 .. raw:: latex

--- a/qgreenland/util/luigi/tasks/pipeline.py
+++ b/qgreenland/util/luigi/tasks/pipeline.py
@@ -163,13 +163,13 @@ class CreateQgisProjectFile(luigi.Task):
             src_filepath=PROJECT_DIR / 'doc' / '_pdf' / 'QuickStartGuide.pdf',
             dest_relative_filepath='QuickStartGuide.pdf',
         )
-        yield AncillaryFile(
-            src_filepath=PROJECT_DIR / 'doc' / '_pdf' / 'UserGuide.pdf',
-            dest_relative_filepath='UserGuide.pdf',
-        )
         yield AncillaryMarkdownFileToHtml(
             src_filepath=PROJECT_DIR / 'CHANGELOG.md',
             dest_relative_filepath='CHANGELOG.html',
+        )
+        yield AncillarySphinxPdfFile(
+            src_filepath=PROJECT_DIR / 'doc' / 'Makefile',
+            dest_relative_filepath='UserGuide.pdf',
         )
         yield PackageLayerList()
 

--- a/qgreenland/util/luigi/tasks/pipeline.py
+++ b/qgreenland/util/luigi/tasks/pipeline.py
@@ -163,13 +163,13 @@ class CreateQgisProjectFile(luigi.Task):
             src_filepath=PROJECT_DIR / 'doc' / '_pdf' / 'QuickStartGuide.pdf',
             dest_relative_filepath='QuickStartGuide.pdf',
         )
+        yield AncillaryFile(
+            src_filepath=PROJECT_DIR / 'doc' / '_pdf' / 'UserGuide.pdf',
+            dest_relative_filepath='UserGuide.pdf',
+        )
         yield AncillaryMarkdownFileToHtml(
             src_filepath=PROJECT_DIR / 'CHANGELOG.md',
             dest_relative_filepath='CHANGELOG.html',
-        )
-        yield AncillarySphinxPdfFile(
-            src_filepath=PROJECT_DIR / 'doc' / 'Makefile',
-            dest_relative_filepath='UserGuide.pdf',
         )
         yield PackageLayerList()
 


### PR DESCRIPTION
## Description

Spit "Reference" section in docs into 'contributor' and 'user' sections so that we can only include the 'user' reference in the pdf included in the qgreenland core package.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [ ] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [ ] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [ ] CHANGELOG.md updated
- [ ] Documentation updated if needed
- [ ] New unit tests if needed
