### PR TITLE
Fix geothermal_heat_flow_map filename

### DIFF
--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -12954,7 +12954,7 @@
                             "EPSG:3413",
                             "-r",
                             "bilinear",
-                            "{input_dir}/geothermal_heat_flow_map_55km.nc",
+                            "{input_dir}/geothermal_heat_flow_map_55km_without_NGRIP.nc",
                             "{output_dir}/warped.tif"
                           ],
                           "type": "command"

--- a/qgreenland/config/layers/Geophysics/Heat flux/Heat flow (Colgan et al.)/geothermal_heat_flow.py
+++ b/qgreenland/config/layers/Geophysics/Heat flux/Heat flow (Colgan et al.)/geothermal_heat_flow.py
@@ -25,7 +25,7 @@ geothermal_heat_flow = Layer(
     ),
     steps=[
         *warp_and_cut(
-            input_file='{input_dir}/geothermal_heat_flow_map_55km.nc',
+            input_file='{input_dir}/geothermal_heat_flow_map_55km_without_NGRIP.nc',
             output_file='{output_dir}/geothermal_heat_flow_map_55km.tif',
             cut_file=project.boundaries['data'].filepath,
         ),


### PR DESCRIPTION
## Description

Update filename for a geothermal_heat_flow_map file causing an error in QA build

## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [ ] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [ ] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [ ] CHANGELOG.md updated
- [ ] Documentation updated if needed
- [ ] New unit tests if needed
