### PR TITLE
Update python version to v3.10

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 incremental = True
 plugins = pydantic.mypy
 show_error_codes = True

--- a/environment-lock.yml
+++ b/environment-lock.yml
@@ -17,27 +17,27 @@ dependencies:
   - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
   - blosc=1.21.3=hafa529b_0
   - boost-cpp=1.78.0=h75c5d50_1
-  - brotlipy=0.7.0=py39hb9d737c_1005
+  - brotlipy=0.7.0=py310h5764c6d_1005
   - bump2version=1.0.1=pyh9f0ad1d_0
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.18.1=h7f98852_0
   - ca-certificates=2022.12.7=ha878542_0
   - cairo=1.16.0=ha61ee94_1014
   - certifi=2022.12.7=pyhd8ed1ab_0
-  - cffi=1.15.1=py39he91dace_3
+  - cffi=1.15.1=py310h255011f_3
   - cfitsio=4.2.0=hd9d235c_0
-  - cftime=1.6.2=py39h2ae25f5_1
-  - chardet=4.0.0=py39hf3d152e_3
+  - cftime=1.6.2=py310hde88566_1
+  - chardet=4.0.0=py310hff52083_3
   - click=7.1.2=pyh9f0ad1d_0
   - click-plugins=1.1.1=py_0
   - cligj=0.7.2=pyhd8ed1ab_1
   - colorama=0.4.6=pyhd8ed1ab_0
-  - coverage=7.0.5=py39h72bdee0_0
-  - cryptography=39.0.0=py39hd598818_0
+  - coverage=7.0.5=py310h1fa729e_0
+  - cryptography=39.0.0=py310h65dfdc0_0
   - curl=7.86.0=h7bff187_1
   - dbus=1.13.6=h5008d03_3
   - decorator=5.1.1=pyhd8ed1ab_0
-  - docutils=0.17.1=py39hf3d152e_3
+  - docutils=0.17.1=py310hff52083_3
   - draco=1.5.5=h924138e_0
   - eigen=3.4.0=h4bd325d_0
   - et_xmlfile=1.0.1=py_1001
@@ -45,7 +45,7 @@ dependencies:
   - exiv2=0.27.6=hb9a316c_0
   - expat=2.5.0=h27087fc_0
   - fftw=3.3.10=nompi_hf0379b8_106
-  - fiona=1.8.22=py39hbc5ff6d_5
+  - fiona=1.8.22=py310ha325b7b_5
   - flake8=3.8.4=py_0
   - flake8-bugbear=21.9.2=pyhd8ed1ab_0
   - flake8-comprehensions=3.2.3=py_0
@@ -64,7 +64,7 @@ dependencies:
   - freexl=1.0.6=h166bdaf_1
   - funcy=1.17=pyhd8ed1ab_0
   - future=0.18.3=pyhd8ed1ab_0
-  - gdal=3.6.0=py39h92c1d47_7
+  - gdal=3.6.0=py310hb7951cf_7
   - geos=3.11.1=h27087fc_0
   - geotiff=1.7.1=ha76d385_4
   - gettext=0.21.1=h27087fc_0
@@ -160,35 +160,35 @@ dependencies:
   - libzip=1.9.2=hc869a4a_1
   - libzlib=1.2.13=h166bdaf_4
   - lockfile=0.12.2=py_1
-  - luigi=3.0.3=py39hf3d152e_2
+  - luigi=3.0.3=py310hff52083_2
   - lz4-c=1.9.3=h9c3ff4c_1
   - markdown=3.3.7=pyhd8ed1ab_0
   - markdown-it-py=1.1.0=pyhd8ed1ab_0
-  - markupsafe=2.1.2=py39h72bdee0_0
+  - markupsafe=2.1.2=py310h1fa729e_0
   - matplotlib-inline=0.1.6=pyhd8ed1ab_0
   - mccabe=0.6.1=py_1
   - mdit-py-plugins=0.2.8=pyhd8ed1ab_0
   - mock=5.0.1=pyhd8ed1ab_0
   - mpg123=1.31.2=hcb278e6_0
   - munch=2.5.0=py_0
-  - mypy=0.990=py39hb9d737c_3
-  - mypy_extensions=0.4.3=py39hf3d152e_6
-  - mysql-common=8.0.31=haf5c9bc_0
-  - mysql-libs=8.0.31=h28c427c_0
+  - mypy=0.990=py310h5764c6d_3
+  - mypy_extensions=0.4.3=py310hff52083_6
+  - mysql-common=8.0.32=h14678bc_0
+  - mysql-libs=8.0.32=h54cf53e_0
   - myst-parser=0.15.2=pyhd8ed1ab_0
   - ncurses=6.3=h27087fc_1
-  - netcdf4=1.6.2=nompi_py39hfaa66c4_100
+  - netcdf4=1.6.2=nompi_py310h55e1e36_100
   - nitro=2.7.dev6=h27087fc_5
   - nose2=0.9.2=py_0
   - nspr=4.35=h27087fc_0
   - nss=3.82=he02c5a1_0
-  - numpy=1.24.1=py39h223a676_0
+  - numpy=1.24.1=py310h08bbf29_0
   - openjpeg=2.5.0=h7d73246_1
-  - openpyxl=3.0.10=py39hb9d737c_2
+  - openpyxl=3.0.10=py310h5764c6d_2
   - openssl=1.1.1s=h0b41bf4_1
   - owslib=0.27.2=pyhd8ed1ab_1
   - packaging=23.0=pyhd8ed1ab_0
-  - pandas=1.5.3=py39h2ad29b5_0
+  - pandas=1.5.3=py310h9b08913_0
   - parso=0.8.3=pyhd8ed1ab_0
   - pcre2=10.40=hc3806b6_0
   - pdal=2.4.3=hbf2fe72_3
@@ -207,8 +207,8 @@ dependencies:
   - proj=9.1.0=h93bde94_0
   - prometheus_client=0.5.0=py_0
   - prompt-toolkit=3.0.36=pyha770c72_0
-  - psutil=5.9.4=py39hb9d737c_0
-  - psycopg2=2.9.3=py39hb9d737c_1
+  - psutil=5.9.4=py310h5764c6d_0
+  - psycopg2=2.9.3=py310h5764c6d_1
   - pthread-stubs=0.4=h36c2ea0_1001
   - ptyprocess=0.7.0=pyhd3deb0d_0
   - pulseaudio=16.1=h4ab2085_1
@@ -216,30 +216,30 @@ dependencies:
   - py=1.11.0=pyh6c4a22f_0
   - pycodestyle=2.6.0=pyh9f0ad1d_0
   - pycparser=2.21=pyhd8ed1ab_0
-  - pydantic=1.10.4=py39h72bdee0_1
+  - pydantic=1.10.4=py310h1fa729e_1
   - pydocstyle=6.3.0=pyhd8ed1ab_0
   - pyflakes=2.2.0=pyh9f0ad1d_0
   - pygments=2.14.0=pyhd8ed1ab_0
   - pyopenssl=23.0.0=pyhd8ed1ab_0
   - pyparsing=3.0.9=pyhd8ed1ab_0
-  - pyproj=3.4.1=py39h12578bd_0
-  - pyqt=5.15.7=py39h18e9c17_2
-  - pyqt5-sip=12.11.0=py39h5a03fae_2
-  - pyqtwebkit=5.15.7=py39ha048f5d_5
+  - pyproj=3.4.1=py310hfc24d34_0
+  - pyqt=5.15.7=py310h29803b5_2
+  - pyqt5-sip=12.11.0=py310hd8f1fbe_2
+  - pyqtwebkit=5.15.7=py310h1165ae2_5
   - pysocks=1.7.1=pyha2e5f31_6
-  - pytest=6.2.5=py39hf3d152e_3
+  - pytest=6.2.5=py310hff52083_3
   - pytest-cov=2.12.1=pyhd8ed1ab_0
-  - python=3.9.15=h47a2c10_0_cpython
+  - python=3.10.8=h257c98d_0_cpython
   - python-daemon=2.3.2=pyhd8ed1ab_0
   - python-dateutil=2.8.2=pyhd8ed1ab_0
-  - python_abi=3.9=3_cp39
+  - python_abi=3.10=3_cp310
   - pytz=2022.7.1=pyhd8ed1ab_0
-  - pyyaml=5.4.1=py39hb9d737c_4
+  - pyyaml=5.4.1=py310h5764c6d_4
   - qca=2.3.5=hb2b434f_1
-  - qgis=3.22.14=py39hc16780f_1
+  - qgis=3.22.14=py310h9f43d86_1
   - qhull=2020.2=h4bd325d_2
   - qjson=0.9.0=hb2b434f_1008
-  - qscintilla2=2.13.3=py39h18e9c17_4
+  - qscintilla2=2.13.3=py310h29803b5_4
   - qt-main=5.15.6=h7acdfc8_2
   - qtkeychain=0.13.2=h7ba989a_1
   - qtwebkit=5.212=h3e5094c_7
@@ -247,9 +247,9 @@ dependencies:
   - readline=8.1.2=h0f457ee_0
   - requests=2.25.1=pyhd3deb0d_0
   - setuptools=66.0.0=pyhd8ed1ab_0
-  - shapely=2.0.0=py39hc9151fd_0
+  - shapely=2.0.0=py310h8b84c32_0
   - shellcheck=0.7.2=ha770c72_1
-  - sip=6.7.5=py39h5a03fae_0
+  - sip=6.7.5=py310hd8f1fbe_0
   - six=1.16.0=pyh6c4a22f_0
   - snappy=1.1.9=hbd366e4_2
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
@@ -268,7 +268,7 @@ dependencies:
   - tk=8.6.12=h27826a3_0
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0
-  - tornado=6.2=py39hb9d737c_1
+  - tornado=6.2=py310h5764c6d_1
   - traitlets=5.8.1=pyhd8ed1ab_0
   - types-click=7.1.8=pyhd8ed1ab_0
   - types-markdown=3.3.31=pyhd8ed1ab_0
@@ -303,7 +303,7 @@ dependencies:
   - yaml=0.2.5=h7f98852_2
   - zipp=3.11.0=pyhd8ed1ab_0
   - zlib=1.2.13=h166bdaf_4
-  - zstd=1.5.2=h3eb15da_5
+  - zstd=1.5.2=h3eb15da_6
   - pip:
       - autodoc-pydantic==1.5.1
       - flake8-commas==2.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python ~=3.9.7
+  - python ~=3.10.0
 
   ################################################################
   # Imported dependencies and extensions (and related typestubs) #


### PR DESCRIPTION
## Description

Upgrade python to 3.10

We'll have to hold off on upgrading to python 3.11 until invoke v2.0 is released on conda-forge. Although invoke v1 can be installed with python v3.11, attempts to use it result in an error. See: https://github.com/pyinvoke/invoke/issues/891

## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
