### PR TITLE
Pass keyword args to shutil.make_archive

### DIFF
--- a/qgreenland/util/luigi/tasks/pipeline.py
+++ b/qgreenland/util/luigi/tasks/pipeline.py
@@ -213,9 +213,9 @@ class ZipQGreenland(luigi.Task):
         shutil.make_archive(
             # make_archive expects a file path without extension:
             f"{tmp_fp.parent}/{tmp_fp.stem}",
-            "zip",
-            WIP_PACKAGE_DIR,
-            input_path.relative_to(WIP_PACKAGE_DIR),
+            format="zip",
+            root_dir=WIP_PACKAGE_DIR,
+            base_dir=input_path.relative_to(WIP_PACKAGE_DIR),
         )
         tmp_fp.rename(output_path)
 


### PR DESCRIPTION
## Description

Use kwargs instead of positional arguments to make code more readable


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
