### PR TITLE
Fix Git error when using CLI: `fatal: detected dubious ownership in repository`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM axiom/docker-luigi:2.8.13-alpine AS luigi
-# This build stage only exists to grab files
+# This docker image simply runs luigi's centralized scheduler with the needed
+# dependencies installed into a conda environment. It's expected that task code
+# will always be mounted in using volumes!
 
-FROM mambaorg/micromamba:1.2.0 AS micromamba
+FROM axiom/docker-luigi:3.0.3-alpine AS luigi
+# This build stage only exists to grab the luigi run script. Luigi dependency
+# itself is specified in `environment.yml`
+
+FROM mambaorg/micromamba:1.4.2 AS micromamba
 COPY --from=luigi /bin/run /usr/local/bin/luigid
 USER root
+
+ENV TASKS_MOUNT_DIR=/luigi/tasks/qgreenland
 
 # `libgl1-mesa-glx` is required for pyqgis
 # `git` is required for analyzing the current version
@@ -16,12 +23,12 @@ RUN apt-get update && apt-get install -y \
   texlive-latex-extra
 
 # Create environments
-RUN micromamba install -y -c conda-forge -n base conda mamba~=1.2.0
+RUN micromamba install -y -c conda-forge -n base conda mamba~=1.4.2
 
-COPY --chown=mambauser:mambauser environment-lock.yml /tmp/environment.yml
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment-lock.yml /tmp/environment.yml
 RUN micromamba install -y -n base -f /tmp/environment.yml
 
-COPY --chown=mambauser:mambauser environment.cmd.yml /tmp/environment.cmd.yml
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment.cmd.yml /tmp/environment.cmd.yml
 RUN micromamba create -y -f /tmp/environment.cmd.yml
 
 # Cleanup
@@ -33,7 +40,8 @@ WORKDIR /luigi
 # doesn't activate the env automatically, which is how the PYTHONPATH normally
 # gets populated. Additionally, /luigi/tasks is where we expect python code to
 # be mounted.
-ENV PYTHONPATH /luigi/tasks/qgreenland:/opt/conda/share/qgis/python/plugins:/opt/conda/share/qgis/python
-ENV PATH /opt/conda/bin:$PATH
+# TODO: With modern micromamba, can we clean this up?
+ENV PYTHONPATH "${TASKS_MOUNT_DIR}:/opt/conda/share/qgis/python/plugins:/opt/conda/share/qgis/python"
+ENV PATH "/opt/conda/bin:${PATH}"
 
 CMD ["/usr/local/bin/luigid"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ RUN apt-get update && apt-get install -y \
   libgl1-mesa-glx \
   texlive-latex-extra
 
+# Enable our code (which runs git commands) to run as a different user than the
+# current user on the host machine (who will be the owner of the mounted git
+# repository)
+RUN git config --global --add safe.directory "${TASKS_MOUNT_DIR}"
+
 # Create environments
 RUN micromamba install -y -c conda-forge -n base conda mamba~=1.4.2
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,6 +51,10 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_notes", "_build", "Thumbs.db", ".DS_Store", "_plugin"]
 
+# -- MyST options -------------------------------------------------
+
+myst_heading_anchors = 3
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/doc/contributor-how-to/run-qgreenland.md
+++ b/doc/contributor-how-to/run-qgreenland.md
@@ -9,6 +9,17 @@ for running tasks, as well as NGINX (port 80, 443) for hosting outputs.
 
 ## How to start the service stack
 
+```{caution}
+Docker Desktop for OSX has some "gotchas". Running with "Use gRPC FUSE for file sharing"
+_enabled_ is recommended. You may see indefinite hangs otherwise. Please reference the
+Docker documentation for more info:
+
+https://docs.docker.com/desktop/mac/
+```
+
+
+### Envvars
+
 In order to download data behind Earthdata Login, you must `export` the
 following environment variables on the docker host before starting the stack:
 
@@ -21,19 +32,19 @@ Earthdata Login credentials. New users to Earthdata can register here:
 https://urs.earthdata.nasa.gov/users/new
 
 
-Create a [docker-compose
-override](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files)
-file for `./logs` and `./appdata`.
+### Directory set up
 
-```
-ln -s docker-compose.local.yml docker-compose.override.yml
-```
+If you prefer not to store data alongside the source code, set up symlinks from the
+following locations to your desired location:
 
-*WARNING*: Docker Desktop for OSX has some "gotchas". Running with "Use gRPC
-FUSE for file sharing" _enabled_ is recommended. You may see indefinite hangs
-otherwise. Please reference the Docker documentation for more info:
+* `./data/private-archive`
+* `./data/working-storage`
 
-https://docs.docker.com/desktop/mac/
+Visit our [storage architecture reference
+documentation](/doc/reference/architecture/storage.md) to learn more.
+
+
+### Go!
 
 Start the stack with docker-compose:
 

--- a/doc/contributor-how-to/run-qgreenland.md
+++ b/doc/contributor-how-to/run-qgreenland.md
@@ -41,7 +41,7 @@ following locations to your desired location:
 * `./data/working-storage`
 
 Visit our [storage architecture reference
-documentation](/doc/reference/architecture/storage.md) to learn more.
+documentation](../reference/architecture/storage.md) to learn more.
 
 
 ### Go!
@@ -83,7 +83,7 @@ testing, but the final output will not be zipped):
 
 Collaborators outside NSIDC may want to run QGreenland pipeline without "manual
 access" layers that require difficult or impossible additional steps to prepare
-input data. See [Assets](/doc/reference/architecture/CONFIGURATION.md#assets)
+input data. See [Assets](../reference/architecture/configuration.md#assets)
 documentation to learn more about "manual access" assets.
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,48 +1,48 @@
-version: '3.4'
+version: "3.4"
 
 services:
 
   # Luigi runs as a service and must have jobs submitted to it
   # (`scripts/run.sh`)
   luigi:
-    image: nsidc/luigi:dev
-    build: .
-    container_name: luigi
+    image: "nsidc/luigi:dev"
+    build: "."
+    container_name: "luigi"
     volumes:
       # Code
-      - ./:/luigi/tasks/qgreenland:ro
+      - "./:/luigi/tasks/qgreenland:ro"
       # Luigi artifacts
-      - ./luigi/conf:/etc/luigi:ro
-      - ./luigi/state:/luigi/state:rw
+      - "./luigi/conf:/etc/luigi:ro"
+      - "./luigi/state:/luigi/state:rw"
 
       # Input (private) storage
-      - ./data/private-archive:/private-archive:ro
+      - "./data/private-archive:/private-archive:ro"
       # Read-write storage
-      - ./data/working-storage:/working-storage:rw
+      - "./data/working-storage:/working-storage:rw"
     environment:
-      - LUIGI_CONFIG_PARSER=toml
-      - ENVIRONMENT
-      - EARTHDATA_USERNAME
-      - EARTHDATA_PASSWORD
+      - "LUIGI_CONFIG_PARSER=toml"
+      - "ENVIRONMENT"
+      - "EARTHDATA_USERNAME"
+      - "EARTHDATA_PASSWORD"
       # Set `export PYTHONBREAKPOINT=ipdb.set_trace` to use `ipdb` by default
       # instead of `pdb`.
-      - PYTHONBREAKPOINT
+      - "PYTHONBREAKPOINT"
       # Needed to properly initialize QGIS Python library without a display
-      - QT_QPA_PLATFORM=minimal
+      - "QT_QPA_PLATFORM=minimal"
     ports:
-      - 8082:8082
+      - "8082:8082"
     logging:
       options:
         max-size: "20m"
         max-file: "5"
-    restart: on-failure
+    restart: "on-failure"
 
 
   # QGreenland hosting
   webserver:
-    image: nsidc/nginx:local
-    build: ./nginx
-    container_name: webserver 
+    image: "nsidc/nginx:local"
+    build: "./nginx"
+    container_name: "webserver"
     volumes:
       # HACK: The ./data symbolic links are messed up to work around an issue
       # with NFS storage.
@@ -50,17 +50,17 @@ services:
       # - ./data/working-storage/release-layers:/usr/share/nginx/html/layers:ro
       # - ./data/working-storage/release-packages:/usr/share/nginx/html/packages:ro
       # New/hack:
-      - /share/appdata/qgreenland/working-storage/release-layers:/usr/share/nginx/html/layers:ro
-      - /share/appdata/qgreenland/working-storage/release-packages:/usr/share/nginx/html/packages:ro
+      - "/share/appdata/qgreenland/working-storage/release-layers:/usr/share/nginx/html/layers:ro"
+      - "/share/appdata/qgreenland/working-storage/release-packages:/usr/share/nginx/html/packages:ro"
       # END HACK
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./data/logs:/logs:rw
+      - "./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro"
+      - "./nginx/nginx.conf:/etc/nginx/nginx.conf:ro"
+      - "./data/logs:/logs:rw"
     ports:
-      - 80:80
-      - 443:443
+      - "80:80"
+      - "443:443"
     logging:
       options:
         max-size: "20m"
         max-file: "5"
-    restart: on-failure
+    restart: "on-failure"

--- a/qgreenland/cli/__init__.py
+++ b/qgreenland/cli/__init__.py
@@ -6,9 +6,12 @@ from qgreenland.cli.fetch import fetch
 from qgreenland.cli.layers import layers
 from qgreenland.cli.provenance import provenance
 from qgreenland.cli.run import run
+from qgreenland.cli.version import version
 
 
-@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.group(
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 def cli():
     ...
 
@@ -19,6 +22,7 @@ cli.add_command(fetch)
 cli.add_command(layers)
 cli.add_command(provenance)
 cli.add_command(run)
+cli.add_command(version)
 
 
 if __name__ == "__main__":

--- a/qgreenland/cli/version.py
+++ b/qgreenland/cli/version.py
@@ -1,0 +1,12 @@
+import click
+
+from qgreenland.constants.paths import PACKAGE_VERSION
+
+
+@click.command()
+def version() -> None:
+    """Print the version of this code.
+
+    NOTE: The QGreenland output zip will be versioned with this string as well.
+    """
+    print(PACKAGE_VERSION)

--- a/qgreenland/constants/paths.py
+++ b/qgreenland/constants/paths.py
@@ -35,7 +35,8 @@ INTERMEDIATE_DIRS = (
 
 # TODO: Extract to function in another module to remove constants dependency on
 # get_build_version, version_is_full_release
-if version_is_full_release(version := get_build_version()):
-    VERSIONED_PACKAGE_DIR = RELEASE_PACKAGES_DIR / version
+PACKAGE_VERSION = get_build_version()
+if version_is_full_release(PACKAGE_VERSION):
+    VERSIONED_PACKAGE_DIR = RELEASE_PACKAGES_DIR / PACKAGE_VERSION
 else:
-    VERSIONED_PACKAGE_DIR = RELEASE_PACKAGES_DIR / "dev" / version
+    VERSIONED_PACKAGE_DIR = RELEASE_PACKAGES_DIR / "dev" / PACKAGE_VERSION


### PR DESCRIPTION
## Description

On any CLI command: `fatal: detected dubious ownership in repository at /luigi/tasks/qgreenland`

This is because we're running a `git` command on a repository that's volume mounted and could be owned by anyone (IMO we should re-visit this choice. Why is code being volume-mounted in in non-dev scenarios?). It wasn't happening before because this is a new check in Git >2.35.

It happens on any CLI command because our `constants.paths` import runs a Git command to determine the version of QGreenland to build a path. This is a problem in itself, and we have a pre-existing TODO to address it, but it's not relevant to the root problem; even if the error isn't triggered on any CLI command, it would be triggered when our code did eventually generate a version string using Git.

* Added a `version` sub-command to see what version string the output Zip file will be tagged without running the whole codebase.
* Updated versions of our Docker image dependencies while I was working on the `Dockerfile`.
* Improved some comments and docs.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
