### PR TITLE
Update geothermal heat flux dataset (Colgan et al.) to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   we received feedback on. These layers were not considered usable.
 - Update the BedMachine dataset ("Terrain models/BedMachine") to v5, which was
   released in September 2022.
+- Update the geothermal heat flow dataset ("Geophysics/Heat flow (Colgan et
+  al.)" layers) to v2.
 
 # v3.0.0alpha2 (2023-05-09)
 

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -560,33 +560,26 @@
     },
     "geothermal_heat_flow": {
       "assets": {
-        "10km_map": {
-          "id": "10km_map",
-          "urls": [
-            "https://dataverse01.geus.dk/api/access/datafile/:persistentId?persistentId=doi:10.22008/FK2/F9P03L/7WDXNF"
-          ],
-          "verify_tls": true
-        },
         "55km_map": {
           "id": "55km_map",
           "urls": [
-            "https://dataverse01.geus.dk/api/access/datafile/:persistentId?persistentId=doi:10.22008/FK2/F9P03L/HJ7AIM"
+            "https://dataverse.geus.dk/api/access/datafile/:persistentId?persistentId=doi:10.22008/FK2/F9P03L/FYNXIL"
           ],
           "verify_tls": true
         },
         "heat_flow_measurements": {
           "id": "heat_flow_measurements",
           "urls": [
-            "https://dataverse01.geus.dk/api/access/datafile/:persistentId?persistentId=doi:10.22008/FK2/F9P03L/JMAXKV"
+            "https://dataverse.geus.dk/api/access/datafile/:persistentId?persistentId=doi:10.22008/FK2/F9P03L/V1IMQX"
           ],
           "verify_tls": true
         }
       },
       "id": "geothermal_heat_flow",
       "metadata": {
-        "abstract": "Database of all geothermal heat flow measurements within 500 km\nof Greenland's coastline with self-consistent machine-learning\ngeothermal heat flow map over all onshore and offshore areas.\n\nRelated publication:\n\nColgan, W., A. Wansing, K. Mankoff, M. L\u00f6sing, J. Hopper, K. Louden,\nJ. Ebbing, F. Christiansen, T. Ingeman-Nielsen, L. Claesson\nLiljedahl, J. MacGregor, \u00c1. Hjartarson, S. Bernstein, N. Karlsson,\nS. Fuchs, J. Hartikainen, J. Liakka, R. Fausto, D. Dahl-Jensen,\nA. Bj\u00f8rk, J.-O. Naslund, F. M\u00f8rk, Y. Martos, N. Balling, T. Funck,\nK. Kjeldsen, D. Petersen, U. Gregersen, G. Dam, T. Nielsen, A. Khan\nand A. L\u00f8kkegaard. Greenland Geothermal Heat Flow Database and Map\n(Version 1). Earth Systems Science Data Discussions. under review.",
+        "abstract": "Database of all geothermal heat flow measurements within 500 km\nof Greenland's coastline with self-consistent machine-learning\ngeothermal heat flow map over all onshore and offshore areas.\n\nRelated publication:\n\nColgan, W., A. Wansing, K. Mankoff, M. L\u00f6sing, J. Hopper, K. Louden,\nJ. Ebbing, F. Christiansen, T. Ingeman-Nielsen, L. Claesson\nLiljedahl, J. MacGregor, \u00c1. Hjartarson, S. Bernstein, N. Karlsson,\nS. Fuchs, J. Hartikainen, J. Liakka, R. Fausto, D. Dahl-Jensen,\nA. Bj\u00f8rk, J.-O. Naslund, F. M\u00f8rk, Y. Martos, N. Balling, T. Funck,\nK. Kjeldsen, D. Petersen, U. Gregersen, G. Dam, T. Nielsen, S. Khan\nand A. L\u00f8kkegaard. Greenland Geothermal Heat Flow Database and Map\n(Version 1). 2022. Earth Systems Science Data. 14: 2209\u20132238. doi:\n10.5194/essd-14-2209-2022.",
         "citation": {
-          "text": "Colgan, William; Wansing, Agnes, 2021, \"Greenland Geothermal\nHeat Flow Database and Map\",\nhttps://doi.org/10.22008/FK2/F9P03L, GEUS Dataverse, V1",
+          "text": "Colgan, William; Wansing, Agnes, 2021, \"Greenland Geothermal\nHeat Flow Database and Map\",\nhttps://doi.org/10.22008/FK2/F9P03L, GEUS Dataverse, V2",
           "url": "https://doi.org/10.22008/FK2/F9P03L"
         },
         "title": "Greenland Geothermal Heat Flow Database and Map"
@@ -12308,7 +12301,7 @@
                 "children": [
                   {
                     "layer_cfg": {
-                      "description": "Heat flow measurement database used in the creation of the 'Geothermal\nheat flow map (10km)' layer.",
+                      "description": "Heat flow measurement database used in the creation of the 'Flow from\nmultiple observations (55km)' layer.",
                       "id": "geothermal_heat_flow_measurements",
                       "in_package": true,
                       "input": {
@@ -12375,7 +12368,7 @@
                             "EPSG:3413",
                             "-r",
                             "bilinear",
-                            "{input_dir}/geothermal_heat_flow_map_55km_without_NGRIP.nc",
+                            "{input_dir}/geothermal_heat_flow_map_55km.nc",
                             "{output_dir}/warped.tif"
                           ],
                           "type": "command"

--- a/qgreenland/config/datasets/geothermal_heat_flow.py
+++ b/qgreenland/config/datasets/geothermal_heat_flow.py
@@ -4,25 +4,18 @@ from qgreenland.models.config.dataset import Dataset
 geothermal_heat_flow = Dataset(
     id="geothermal_heat_flow",
     assets=[
-        # This is interpolated data.
-        # TODO: is there anything special about the upsampling done here?
-        HttpAsset(
-            id="10km_map",
-            urls=[
-                "https://dataverse01.geus.dk/api/access/datafile/:persistentId?persistentId=doi:10.22008/FK2/F9P03L/7WDXNF"
-            ],
-        ),
-        # This is the native resolution
+        # A 10km map is also available but it is upsampled. This is the native
+        # resolution
         HttpAsset(
             id="55km_map",
             urls=[
-                "https://dataverse01.geus.dk/api/access/datafile/:persistentId?persistentId=doi:10.22008/FK2/F9P03L/HJ7AIM"
+                "https://dataverse.geus.dk/api/access/datafile/:persistentId?persistentId=doi:10.22008/FK2/F9P03L/FYNXIL"
             ],
         ),
         HttpAsset(
             id="heat_flow_measurements",
             urls=[
-                "https://dataverse01.geus.dk/api/access/datafile/:persistentId?persistentId=doi:10.22008/FK2/F9P03L/JMAXKV"
+                "https://dataverse.geus.dk/api/access/datafile/:persistentId?persistentId=doi:10.22008/FK2/F9P03L/V1IMQX"
             ],
         ),
     ],
@@ -40,15 +33,16 @@ geothermal_heat_flow = Dataset(
             Liljedahl, J. MacGregor, Á. Hjartarson, S. Bernstein, N. Karlsson,
             S. Fuchs, J. Hartikainen, J. Liakka, R. Fausto, D. Dahl-Jensen,
             A. Bjørk, J.-O. Naslund, F. Mørk, Y. Martos, N. Balling, T. Funck,
-            K. Kjeldsen, D. Petersen, U. Gregersen, G. Dam, T. Nielsen, A. Khan
+            K. Kjeldsen, D. Petersen, U. Gregersen, G. Dam, T. Nielsen, S. Khan
             and A. Løkkegaard. Greenland Geothermal Heat Flow Database and Map
-            (Version 1). Earth Systems Science Data Discussions. under review."""
+            (Version 1). 2022. Earth Systems Science Data. 14: 2209–2238. doi:
+            10.5194/essd-14-2209-2022."""
         ),
         "citation": {
             "text": (
                 """Colgan, William; Wansing, Agnes, 2021, "Greenland Geothermal
                 Heat Flow Database and Map",
-                https://doi.org/10.22008/FK2/F9P03L, GEUS Dataverse, V1"""
+                https://doi.org/10.22008/FK2/F9P03L, GEUS Dataverse, V2"""
             ),
             "url": "https://doi.org/10.22008/FK2/F9P03L",
         },

--- a/qgreenland/config/layers/Geophysics/Heat flux/Heat flow (Colgan et al.)/geothermal_heat_flow.py
+++ b/qgreenland/config/layers/Geophysics/Heat flux/Heat flow (Colgan et al.)/geothermal_heat_flow.py
@@ -26,7 +26,7 @@ geothermal_heat_flow = Layer(
     ),
     steps=[
         *warp_and_cut(
-            input_file="{input_dir}/geothermal_heat_flow_map_55km_without_NGRIP.nc",
+            input_file="{input_dir}/geothermal_heat_flow_map_55km.nc",
             output_file="{output_dir}/geothermal_heat_flow_map_55km.tif",
             cut_file=project.boundaries["data"].filepath,
         ),
@@ -42,8 +42,8 @@ geothermal_heat_flow_measurements = Layer(
     id="geothermal_heat_flow_measurements",
     title="Flow measurement locations",
     description=(
-        """Heat flow measurement database used in the creation of the 'Geothermal
-        heat flow map (10km)' layer."""
+        """Heat flow measurement database used in the creation of the 'Flow from
+        multiple observations (55km)' layer."""
     ),
     tags=[],
     input=LayerInput(


### PR DESCRIPTION
## Description

Upgrade to v2 of the Colgan et al. geothermal heat flux dataset. Links to v1 data were broken.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
