### PR TITLE
When the conda lock file is installed after mamba, mamba gets removed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,12 @@ RUN apt-get update && apt-get install -y \
 # repository)
 RUN git config --global --add safe.directory "${TASKS_MOUNT_DIR}"
 
-# Create environments
-RUN micromamba install -y -c conda-forge -n base conda mamba~=1.4.2
-
 # Why are we copying these files to /tmp?
 COPY --chown=$MAMBA_USER:$MAMBA_USER conda-lock.yml /tmp/conda-lock.yml
 RUN micromamba install -y -n base -f /tmp/conda-lock.yml
+
+# Create environments
+RUN micromamba install -y -c conda-forge -n base conda mamba~=1.4.2
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.cmd.yml /tmp/environment.cmd.yml
 RUN micromamba create -y -f /tmp/environment.cmd.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,11 @@ RUN apt-get update && apt-get install -y \
 # repository)
 RUN git config --global --add safe.directory "${TASKS_MOUNT_DIR}"
 
-# Why are we copying these files to /tmp?
+# TODO: Why are we copying these files to /tmp?
 COPY --chown=$MAMBA_USER:$MAMBA_USER conda-lock.yml /tmp/conda-lock.yml
 RUN micromamba install -y -n base -f /tmp/conda-lock.yml
 
-# Create environments
+# Install mamba. It is missing after installing `conda-lock.yml`
 RUN micromamba install -y -c conda-forge -n base conda mamba~=1.4.2
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.cmd.yml /tmp/environment.cmd.yml


### PR DESCRIPTION
Not sure exactly what's happening here, but without this change, we get this error when trying to run the image:

```
Traceback (most recent call last):
  File "/opt/conda/bin/mamba", line 7, in <module>
    from mamba.mamba import main
ModuleNotFoundError: No module named 'mamba'
```

## Description

REPLACE ME WITH A PULL REQUEST DESCRIPTION.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
