### PR TITLE
Add blue marble wms layer from GIBS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Remove outdated "Terrain Models/Topographic map (1 to 500,000)" layer from the
   Danish Agency for Data Supply and Infrastructure (SDFI). Replaced by above
   mentioned "Internet-required data/Topographic map of Greenland" WMS layer.
+- Add new "Internet-required data/Blue Marble shaded relief and Bathymetry
+  (500m)" WMS layer from NASA Global Imagery Browse Services (GIBS)
 
 
 # v3.0.0alpha2 (2023-05-09)

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -588,6 +588,24 @@
         "title": "Geothermal heat flux distribution for the Greenland ice sheet, derived by combining a global representation and information from deep ice cores"
       }
     },
+    "gibs": {
+      "assets": {
+        "only": {
+          "id": "only",
+          "provider": "wms",
+          "url": "contextualWMSLegend=0&crs=EPSG:3413&dpiMode=7&featureCount=10&format=image/png&layers=BlueMarble_ShadedRelief_Bathymetry&styles&url=https://gibs.earthdata.nasa.gov/wms/epsg3413/best/wms.cgi?VERSION%3D1.3.0"
+        }
+      },
+      "id": "gibs",
+      "metadata": {
+        "abstract": "NASA GIBS provides full-resolution visual representations of NASA\nEarth science data in a free, open, and interoperable\nmanner. Through responsive and highly available web services, it\nenables interactive exploration of data to support a wide range of\napplications including scientific research, applied sciences,\nnatural hazard monitoring, and outreach.",
+        "citation": {
+          "text": "We acknowledge the use of imagery provided by services from\nNASA's Global Imagery Browse Services (GIBS), part of NASA's\nEarth Observing System Data and Information System (EOSDIS).",
+          "url": "https://www.earthdata.nasa.gov/eosdis/science-system-description/eosdis-components/gibs"
+        },
+        "title": "Global Imagery Browse Services (GIBS)"
+      }
+    },
     "glacier_terminus": {
       "assets": {
         "2000_2001": {
@@ -25358,6 +25376,29 @@
               "title": "Topographic map of Greenland"
             },
             "name": "sdfi_topo_map"
+          },
+          {
+            "layer_cfg": {
+              "description": "Blue Marble (August 2004, Shaded Relief and Bathymetry).\n\nThe MODIS Blue Marble, Next Generation layer with Shaded Relief and\nBathymetry is a cloud free, true color composite of MODIS imagery from\nAugust 2004 including shaded relief and bathymetry in the water bodies.\n\nThe MODIS Blue Marble, Next Generation is a static product created with data\nfrom 2004 from the MODIS instrument on board the Terra satellite. The image\nresolution is 500 m. It can be viewed in Worldview/Global Imagery Browse\nServices (GIBS). Images for January \u2013 December 2004 can be downloaded from\nNASA\u2019s Visible Earth.\n\nReferences: NASA Earth Observatory - Blue Marble\n[https://earthobservatory.nasa.gov/features/BlueMarble]; NASA Earth\nObservations - Blue Marble\n[https://neo.gsfc.nasa.gov/view.php?datasetId=BlueMarbleNG-TB]; NASA\nEarth Observations - Blue Marble: Next Generation+Topography and\nBathymetry\n[https://neo.gsfc.nasa.gov/view.php?datasetId=BlueMarbleNG-TB].",
+              "id": "blue_marble_shaded_relif_bathymetry",
+              "in_package": true,
+              "input": {
+                "asset": {
+                  "id": "only"
+                },
+                "dataset": {
+                  "id": "gibs"
+                }
+              },
+              "show": false,
+              "steps": null,
+              "style": null,
+              "tags": [
+                "online"
+              ],
+              "title": "Blue Marble shaded relief and Bathymetry (500m)"
+            },
+            "name": "blue_marble_shaded_relif_bathymetry"
           }
         ],
         "name": "Internet-required data",
@@ -25367,7 +25408,8 @@
             ":image_mosaic_2019",
             ":image_mosaic_2015",
             ":sdfi_satellite_orthophotos",
-            ":sdfi_topo_map"
+            ":sdfi_topo_map",
+            ":blue_marble_shaded_relif_bathymetry"
           ],
           "show": false
         }

--- a/qgreenland/config/datasets/online.py
+++ b/qgreenland/config/datasets/online.py
@@ -1,6 +1,36 @@
 from qgreenland.models.config.asset import OnlineAsset
 from qgreenland.models.config.dataset import Dataset, DatasetMetadata
 
+gibs = Dataset(
+    id="gibs",
+    assets=[
+        OnlineAsset(
+            id="only",
+            provider="wms",
+            url="contextualWMSLegend=0&crs=EPSG:3413&dpiMode=7&featureCount=10&format=image/png&layers=BlueMarble_ShadedRelief_Bathymetry&styles&url=https://gibs.earthdata.nasa.gov/wms/epsg3413/best/wms.cgi?VERSION%3D1.3.0",
+        ),
+    ],
+    metadata=DatasetMetadata(
+        title="Global Imagery Browse Services (GIBS)",
+        abstract=(
+            """NASA GIBS provides full-resolution visual representations of NASA
+            Earth science data in a free, open, and interoperable
+            manner. Through responsive and highly available web services, it
+            enables interactive exploration of data to support a wide range of
+            applications including scientific research, applied sciences,
+            natural hazard monitoring, and outreach."""
+        ),
+        citation={
+            "text": (
+                """We acknowledge the use of imagery provided by services from
+                NASA's Global Imagery Browse Services (GIBS), part of NASA's
+                Earth Observing System Data and Information System (EOSDIS)."""
+            ),
+            "url": "https://www.earthdata.nasa.gov/eosdis/science-system-description/eosdis-components/gibs",
+        },
+    ),
+)
+
 # TODO: combine SDFI topo and satellite photos into one dataset with multiple
 # assets? Better citation for these two?
 sdfi_topo_map = Dataset(

--- a/qgreenland/config/layers/Internet-required data/__settings__.py
+++ b/qgreenland/config/layers/Internet-required data/__settings__.py
@@ -6,5 +6,6 @@ settings = LayerGroupSettings(
         ":image_mosaic_2015",
         ":sdfi_satellite_orthophotos",
         ":sdfi_topo_map",
+        ":blue_marble_shaded_relif_bathymetry",
     ],
 )

--- a/qgreenland/config/layers/Internet-required data/online.py
+++ b/qgreenland/config/layers/Internet-required data/online.py
@@ -1,9 +1,42 @@
 from qgreenland.config.datasets.online import (
+    gibs,
     image_mosaic,
     sdfi_satellite_orthophotos,
     sdfi_topo_map,
 )
 from qgreenland.models.config.layer import Layer, LayerInput
+
+blue_marble_layer = Layer(
+    id="blue_marble_shaded_relif_bathymetry",
+    title="Blue Marble shaded relief and Bathymetry (500m)",
+    description=(
+        """Blue Marble (August 2004, Shaded Relief and Bathymetry).
+
+        The MODIS Blue Marble, Next Generation layer with Shaded Relief and
+        Bathymetry is a cloud free, true color composite of MODIS imagery from
+        August 2004 including shaded relief and bathymetry in the water bodies.
+
+        The MODIS Blue Marble, Next Generation is a static product created with data
+        from 2004 from the MODIS instrument on board the Terra satellite. The image
+        resolution is 500 m. It can be viewed in Worldview/Global Imagery Browse
+        Services (GIBS). Images for January – December 2004 can be downloaded from
+        NASA’s Visible Earth.
+
+        References: NASA Earth Observatory - Blue Marble
+        [https://earthobservatory.nasa.gov/features/BlueMarble]; NASA Earth
+        Observations - Blue Marble
+        [https://neo.gsfc.nasa.gov/view.php?datasetId=BlueMarbleNG-TB]; NASA
+        Earth Observations - Blue Marble: Next Generation+Topography and
+        Bathymetry
+        [https://neo.gsfc.nasa.gov/view.php?datasetId=BlueMarbleNG-TB]."""
+    ),
+    tags=["online"],
+    input=LayerInput(
+        dataset=gibs,
+        asset=gibs.assets["only"],
+    ),
+)
+
 
 image_mosaic_layers = [
     Layer(


### PR DESCRIPTION
## Description

Blue marble shaded relief and bathymetry at 500m from GIBS.

There are some other layers from GIBS we may want to consider. For example, there are other versions of Blue Marble (the 'extended extent' would probably be a good choice, but it does not include bathemetry and actually extends beyond the QGreenland project boundary).

There are also science variables that appear to work correctly in QGIS' temporal controller! E.g., Cloud Top Temperature.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
