### PR TITLE
Update bathymetry contours layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,11 @@
   grid. This update includes the most recent data and expands the spatial extent
   of this layer to the QGreenland background boundary to make it consistent with
   other ocenaography layers.
-
+- Update "Oceanography/Bathymetry/Depth contours" layer to be derived from the
+  General Bathymetric Chart of the Oceans (GEBCO) Grid 2023, replacing the
+  contours obtained from the Geological map of the Arctic / Carte gologique de
+  l'Arctique (2011) dataset, which was based on the Bathymetric Chart of the
+  Arctic Ocean (IBCAO).
 
 # v3.0.0alpha2 (2023-05-09)
 

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -25204,7 +25204,7 @@
             "children": [
               {
                 "layer_cfg": {
-                  "description": "Bathymetric elevation in meters.\n\nElevations can be assumed to be relative to mean sea level. However, in\nsome shallow water areas, the grids include data from sources having a\nvertical datum other than mean sea level. We are working to understand\nhow best to fully assimilate these data.",
+                  "description": "Bathymetric elevation in meters.\n\nNegative values represent bathymetric depths and positive values are\ntopographic heights.\n\nElevations can be assumed to be relative to mean sea level. However, in\nsome shallow water areas, the grids include data from sources having a\nvertical datum other than mean sea level. We are working to understand\nhow best to fully assimilate these data.",
                   "id": "gebco_bathymetric_raster",
                   "in_package": true,
                   "input": {
@@ -25297,15 +25297,15 @@
               },
               {
                 "layer_cfg": {
-                  "description": "This dataset includes linear features that represent\n bathymetric contours recorded in metres,\nderived from the International Bathymetric Chart of the Arctic Ocean.",
-                  "id": "bathymetric_contours",
+                  "description": "Bathymetric elevation contours in meters.\n\nContour interval is 100m and was derived from the \"Depth (400m)\" layer.\n\nElevations can be assumed to be relative to mean sea level. However, in\nsome shallow water areas, the grids include data from sources having a\nvertical datum other than mean sea level. We are working to understand\nhow best to fully assimilate these data.",
+                  "id": "gebco_bathymetric_contours",
                   "in_package": true,
                   "input": {
                     "asset": {
                       "id": "only"
                     },
                     "dataset": {
-                      "id": "geological_map"
+                      "id": "gebco_bathymetric_chart"
                     }
                   },
                   "show": false,
@@ -25313,25 +25313,65 @@
                     {
                       "args": [
                         "unzip",
-                        "{input_dir}/as_2159.zip",
+                        "{input_dir}/gebco_2023.zip",
                         "-d",
                         "{output_dir}",
-                        "data/shape/base/bathymetry.*"
+                        ""
                       ],
                       "type": "command"
                     },
                     {
                       "args": [
-                        "ogr2ogr",
-                        "-lco",
-                        "ENCODING=UTF-8",
+                        "gdalwarp",
                         "-t_srs",
                         "EPSG:3413",
-                        "-clipdst",
+                        "-r",
+                        "bilinear",
+                        "-te",
+                        "-5774572.727594967 -5774572.727594967 5774572.727594967 5774572.727594967",
+                        "-tr",
+                        "400",
+                        "400",
+                        "NETCDF:{input_dir}/GEBCO_2023.nc:elevation",
+                        "{output_dir}/warped.tif"
+                      ],
+                      "type": "command"
+                    },
+                    {
+                      "args": [
+                        "gdalwarp",
+                        "-cutline",
                         "{assets_dir}/latitude_shape_40_degrees.geojson",
-                        "-makevalid",
-                        "{output_dir}/final.gpkg",
-                        "{input_dir}/data/shape/base/bathymetry.shp"
+                        "-crop_to_cutline",
+                        "-co",
+                        "COMPRESS=DEFLATE",
+                        "{input_dir}/warped.tif",
+                        "{output_dir}/bathymetric_chart.tif"
+                      ],
+                      "type": "command"
+                    },
+                    {
+                      "args": [
+                        "gdal_calc.py",
+                        "--calc=\"where(A < 0, absolute(A), nan)\"",
+                        "--A_band=1",
+                        "-A",
+                        "{input_dir}/bathymetric_chart.tif",
+                        "--outfile={output_dir}/positive_depths.tif"
+                      ],
+                      "type": "command"
+                    },
+                    {
+                      "args": [
+                        "gdal_contour",
+                        "-a",
+                        "DEPTH",
+                        "-i",
+                        "500",
+                        "-nln",
+                        "bathymetry",
+                        "{input_dir}/positive_depths.tif",
+                        "{output_dir}/bathymetric_chart.gpkg"
                       ],
                       "type": "command"
                     }
@@ -25340,7 +25380,7 @@
                   "tags": [],
                   "title": "Depth contours"
                 },
-                "name": "bathymetric_contours"
+                "name": "gebco_bathymetric_contours"
               }
             ],
             "name": "Bathymetry",

--- a/qgreenland/config/layers/Oceanography/Bathymetry/bathymetric_chart.py
+++ b/qgreenland/config/layers/Oceanography/Bathymetry/bathymetric_chart.py
@@ -1,5 +1,4 @@
 from qgreenland.config.datasets.bathymetric_chart import gebco_bathymetric_chart
-from qgreenland.config.helpers.layers.geological_map import make_layer
 from qgreenland.config.helpers.steps.compress_and_add_overviews import (
     compress_and_add_overviews,
 )
@@ -7,6 +6,7 @@ from qgreenland.config.helpers.steps.decompress import decompress_step
 from qgreenland.config.helpers.steps.warp_and_cut import warp_and_cut
 from qgreenland.config.project import project
 from qgreenland.models.config.layer import Layer, LayerInput
+from qgreenland.models.config.step import CommandStep
 
 _background_boundary = project.boundaries["background"]
 _background_bbox = _background_boundary.bbox
@@ -15,6 +15,9 @@ gebco_bathymetric_raster = Layer(
     title="Depth (400m)",
     description=(
         """Bathymetric elevation in meters.
+
+        Negative values represent bathymetric depths and positive values are
+        topographic heights.
 
         Elevations can be assumed to be relative to mean sea level. However, in
         some shallow water areas, the grids include data from sources having a
@@ -49,21 +52,61 @@ gebco_bathymetric_raster = Layer(
     ],
 )
 
+gebco_bathymetric_contours = Layer(
+    id="gebco_bathymetric_contours",
+    title="Depth contours",
+    description=(
+        """Bathymetric elevation contours in meters.
 
-bathymetric_contours_params = {
-    "id": "bathymetric_contours",
-    "title": "Depth contours",
-    "description": (
-        """This dataset includes linear features that represent
-         bathymetric contours recorded in metres,
-        derived from the International Bathymetric Chart of the Arctic Ocean."""
+        Contour interval is 100m and was derived from the "Depth (400m)" layer.
+
+        Elevations can be assumed to be relative to mean sea level. However, in
+        some shallow water areas, the grids include data from sources having a
+        vertical datum other than mean sea level. We are working to understand
+        how best to fully assimilate these data."""
     ),
-    "style": "bathymetry",
-    "input_filepath": "data/shape/base/bathymetry",
-    "fn_mask": "bathymetry.*",
-}
-
-bathymetric_contours = make_layer(
-    layer_id=bathymetric_contours_params["id"],
-    layer_params=bathymetric_contours_params,
+    tags=[],
+    style="bathymetry",
+    input=LayerInput(
+        dataset=gebco_bathymetric_chart,
+        asset=gebco_bathymetric_chart.assets["only"],
+    ),
+    steps=[
+        decompress_step(input_file="{input_dir}/gebco_2023.zip"),
+        *warp_and_cut(
+            input_file="NETCDF:{input_dir}/GEBCO_2023.nc:elevation",
+            output_file="{output_dir}/bathymetric_chart.tif",
+            reproject_args=(
+                "-te",
+                f"{_background_bbox.min_x} {_background_bbox.min_y} {_background_bbox.max_x} {_background_bbox.max_y}",
+                "-tr",
+                "400",
+                "400",
+            ),
+            cut_file=project.boundaries["background"].filepath,
+        ),
+        CommandStep(
+            args=[
+                "gdal_calc.py",
+                '--calc="where(A < 0, absolute(A), nan)"',
+                "--A_band=1",
+                "-A",
+                "{input_dir}/bathymetric_chart.tif",
+                "--outfile={output_dir}/positive_depths.tif",
+            ],
+        ),
+        CommandStep(
+            args=[
+                "gdal_contour",
+                "-a",
+                "DEPTH",
+                "-i",
+                "500",
+                "-nln",
+                "bathymetry",
+                "{input_dir}/positive_depths.tif",
+                "{output_dir}/bathymetric_chart.gpkg",
+            ],
+        ),
+    ],
 )


### PR DESCRIPTION
## Description

Having updated the raster bathymetry layer in https://github.com/nsidc/qgreenland/pull/584, the "Depth contours" layer (the subject of this PR) is the only remaining Oceanography layer that does not have data covering the entire background boundary.

Currently, the "Depth contours" layer is obtained from the "Geological map of the Arctic / Carte gologique de l'Arctique" (2011) dataset, (the depth contours of which was based on the Bathymetric Chart of the Arctic Ocean (IBCAO)). The geological map dataset is used for our "Geology/Geological map" layers and the bathemetry contours are provided with the dataset for additional context.

Comparing contours in the geological map dataset to the current GEBCO grid shows some disagreement along the coasts. Given that the contours dataset seems to be outdated and only covers a portion of the Arctic, I figured I would use `gdal_contour` to generate our own contours from the GEBCO 2023 grid added in PR #584.  That's this PR.

However, this dataset is a bit larger than our existing one on disk (~120M w/ a 500m contour interval instead of ~65M). Perhaps this is acceptable, but is there much benefit in even including this dataset? A user could use the processing toolbox to create their own contours layer from the "Depth (400m)" raster at any contour interval they desired. E.g., a 100m contour interval produces a file ~500M in size. 


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
