### PR TITLE
Remove "Oceanography/Bathymetry/Depth contours" layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,15 @@
   grid. This update includes the most recent data and expands the spatial extent
   of this layer to the QGreenland background boundary to make it consistent with
   other ocenaography layers.
-
+- Remove "Oceanography/Bathymetry/Depth contours" layer. This layer was pulled
+  from the "Geological map of the Arctic / Carte gologique de l'Arctique"
+  (Harrison et al., 2011) dataset and was provided with the geological data for
+  additional context. It was derived from the (IBCAO) grid. Comparing this with
+  the current IBCAO and GEBCO grids, these contours seem outdated. They also
+  only cover a portion of QGreenland's background extent. Users can produce
+  their own custom contour layer from the included
+  "Oceanography/Bathymetry/Depth (400m)" layer using the Processing Toolbox
+  (GDAL -> Raster extraction -> Contour).
 
 # v3.0.0alpha2 (2023-05-09)
 

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -25294,53 +25294,6 @@
                   "title": "Depth (400m)"
                 },
                 "name": "gebco_bathymetric_raster"
-              },
-              {
-                "layer_cfg": {
-                  "description": "This dataset includes linear features that represent\n bathymetric contours recorded in metres,\nderived from the International Bathymetric Chart of the Arctic Ocean.",
-                  "id": "bathymetric_contours",
-                  "in_package": true,
-                  "input": {
-                    "asset": {
-                      "id": "only"
-                    },
-                    "dataset": {
-                      "id": "geological_map"
-                    }
-                  },
-                  "show": false,
-                  "steps": [
-                    {
-                      "args": [
-                        "unzip",
-                        "{input_dir}/as_2159.zip",
-                        "-d",
-                        "{output_dir}",
-                        "data/shape/base/bathymetry.*"
-                      ],
-                      "type": "command"
-                    },
-                    {
-                      "args": [
-                        "ogr2ogr",
-                        "-lco",
-                        "ENCODING=UTF-8",
-                        "-t_srs",
-                        "EPSG:3413",
-                        "-clipdst",
-                        "{assets_dir}/latitude_shape_40_degrees.geojson",
-                        "-makevalid",
-                        "{output_dir}/final.gpkg",
-                        "{input_dir}/data/shape/base/bathymetry.shp"
-                      ],
-                      "type": "command"
-                    }
-                  ],
-                  "style": "bathymetry",
-                  "tags": [],
-                  "title": "Depth contours"
-                },
-                "name": "bathymetric_contours"
               }
             ],
             "name": "Bathymetry",

--- a/qgreenland/config/layers/Oceanography/Bathymetry/bathymetric_chart.py
+++ b/qgreenland/config/layers/Oceanography/Bathymetry/bathymetric_chart.py
@@ -1,5 +1,4 @@
 from qgreenland.config.datasets.bathymetric_chart import gebco_bathymetric_chart
-from qgreenland.config.helpers.layers.geological_map import make_layer
 from qgreenland.config.helpers.steps.compress_and_add_overviews import (
     compress_and_add_overviews,
 )
@@ -47,23 +46,4 @@ gebco_bathymetric_raster = Layer(
             dtype_is_float=False,
         ),
     ],
-)
-
-
-bathymetric_contours_params = {
-    "id": "bathymetric_contours",
-    "title": "Depth contours",
-    "description": (
-        """This dataset includes linear features that represent
-         bathymetric contours recorded in metres,
-        derived from the International Bathymetric Chart of the Arctic Ocean."""
-    ),
-    "style": "bathymetry",
-    "input_filepath": "data/shape/base/bathymetry",
-    "fn_mask": "bathymetry.*",
-}
-
-bathymetric_contours = make_layer(
-    layer_id=bathymetric_contours_params["id"],
-    layer_params=bathymetric_contours_params,
 )


### PR DESCRIPTION
## Description

This PR removes the "Oceanography/Bathymetry/Depth contours" layer. 

This layer was pulled from the "Geological map of the Arctic / Carte gologique
de l'Arctique" (Harrison et al., 2011) dataset and was provided with the
geological data for additional context. It was derived from the (IBCAO)
grid. Comparing this with the current IBCAO and GEBCO grids, these contours seem
outdated. They also only cover a portion of QGreenland's background
extent. Users can produce their own custom contour layer from the included
"Oceanography/Bathymetry/Depth (400m)" layer using the Processing Toolbox (GDAL
-> Raster extraction -> Contour).

This PR supersedes https://github.com/nsidc/qgreenland/pull/586 

## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
