### PR TITLE
Arctic vegetation cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
   stations", "GC-Net automated weather stations") with one layer ("PROMICE and
   GC-Net automated weather stations") from a more up-to-date dataset provided by
   GEUS.
+- Add new "Biology/Vegetation/Vegetation classification map (1km)" layer from
+  the Raster Circumpolar Arctic Vegetation Map produced by Raynolds et al.,
+  2019.
 
 # v3.0.0alpha2 (2023-05-09)
 

--- a/qgreenland/ancillary/styles/arctic_vegetation.qml
+++ b/qgreenland/ancillary/styles/arctic_vegetation.qml
@@ -1,0 +1,175 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis hasScaleBasedVisibilityFlag="0" version="3.28.7-Firenze" maxScale="0" minScale="1e+08" styleCategories="AllStyleCategories">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <temporal fetchMode="0" mode="0" enabled="0">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <elevation symbology="Line" zoffset="0" band="1" enabled="0" zscale="1">
+    <data-defined-properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </data-defined-properties>
+    <profileLineSymbol>
+      <symbol alpha="1" frame_rate="10" is_animated="0" type="line" clip_to_extent="1" force_rhr="0" name="">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer pass="0" class="SimpleLine" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="square" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="114,155,111,255" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.6" name="line_width"/>
+            <Option type="QString" value="MM" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileLineSymbol>
+    <profileFillSymbol>
+      <symbol alpha="1" frame_rate="10" is_animated="0" type="fill" clip_to_extent="1" force_rhr="0" name="">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="114,155,111,255" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="no" name="outline_style"/>
+            <Option type="QString" value="0.26" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileFillSymbol>
+  </elevation>
+  <customproperties>
+    <Option type="Map">
+      <Option type="bool" value="false" name="WMSBackgroundLayer"/>
+      <Option type="bool" value="false" name="WMSPublishDataSourceUrl"/>
+      <Option type="int" value="0" name="embeddedWidgets/count"/>
+      <Option type="QString" value="Value" name="identify/format"/>
+    </Option>
+  </customproperties>
+  <pipe-data-defined-properties>
+    <Option type="Map">
+      <Option type="QString" value="" name="name"/>
+      <Option name="properties"/>
+      <Option type="QString" value="collection" name="type"/>
+    </Option>
+  </pipe-data-defined-properties>
+  <pipe>
+    <provider>
+      <resampling zoomedInResamplingMethod="nearestNeighbour" zoomedOutResamplingMethod="nearestNeighbour" maxOversampling="2" enabled="false"/>
+    </provider>
+    <rasterrenderer opacity="1" alphaBand="-1" type="paletted" band="1" nodataColor="">
+      <rasterTransparency/>
+      <minMaxOrigin>
+        <limits>None</limits>
+        <extent>WholeRaster</extent>
+        <statAccuracy>Estimated</statAccuracy>
+        <cumulativeCutLower>0.02</cumulativeCutLower>
+        <cumulativeCutUpper>0.98</cumulativeCutUpper>
+        <stdDevFactor>2</stdDevFactor>
+      </minMaxOrigin>
+      <colorPalette>
+        <paletteEntry alpha="255" label="B1 - Cryptogam, herb barren" color="#cdcfa8" value="1"/>
+        <paletteEntry alpha="255" label="B2a - Cryptogam, barren complex" color="#939a33" value="2"/>
+        <paletteEntry alpha="255" label="B3 - Non-carbonate mountain complex" color="#896f70" value="3"/>
+        <paletteEntry alpha="255" label="B4 - Carbonate mountain complex" color="#706d8c" value="4"/>
+        <paletteEntry alpha="255" label="B2b - Cryptogam, barren, dwarf-shrub complex" color="#a9b259" value="5"/>
+        <paletteEntry alpha="255" label="G1 - Graminoid, forb, cryptogam tundra" color="#f5e8a2" value="21"/>
+        <paletteEntry alpha="255" label="G2 - Graminoid, prostrate dwarf-shrub, forb, moss tundra" color="#eccc75" value="22"/>
+        <paletteEntry alpha="255" label="G3 - Non-tussock sedge, dwarf-shrub, moss tundra" color="#c6b62f" value="23"/>
+        <paletteEntry alpha="255" label="G4 - Tussock-sedge, dwarf-shrub, moss tundra" color="#ecec32" value="24"/>
+        <paletteEntry alpha="255" label="P1 - Prostrate dwarf-shrub, herb, lichen tundra" color="#c5a1a1" value="31"/>
+        <paletteEntry alpha="255" label="P2 - Prostrate/hemi-prostrate dwarf-shrub, lichen tundra" color="#ba828d" value="32"/>
+        <paletteEntry alpha="255" label="S1 - Erect dwarf-shrub, moss tundra" color="#9ac339" value="33"/>
+        <paletteEntry alpha="255" label="S2 - Low-shrub, moss tundra" color="#599a3e" value="34"/>
+        <paletteEntry alpha="255" label="W1 - Sedge/grass, moss wetland complex" color="#aacea8" value="41"/>
+        <paletteEntry alpha="255" label="W2 - Sedge, moss, dwarf-shrub wetland complex" color="#9ac8bd" value="42"/>
+        <paletteEntry alpha="255" label="W3 - Sedge, moss, low-shrub wetland complex" color="#74b289" value="43"/>
+        <paletteEntry alpha="255" label="FW - Fresh water" color="#4656a3" value="91"/>
+        <paletteEntry alpha="255" label="SW - Saline water" color="#bbc4e5" value="92"/>
+        <paletteEntry alpha="255" label="GL - Glacier" color="#ffffff" value="93"/>
+        <paletteEntry alpha="255" label="NA - Non-Arctic" color="#f6e9b5" value="99"/>
+      </colorPalette>
+      <colorramp type="gradient" name="[source]">
+        <Option type="Map">
+          <Option type="QString" value="215,25,28,255" name="color1"/>
+          <Option type="QString" value="43,131,186,255" name="color2"/>
+          <Option type="QString" value="ccw" name="direction"/>
+          <Option type="QString" value="0" name="discrete"/>
+          <Option type="QString" value="gradient" name="rampType"/>
+          <Option type="QString" value="rgb" name="spec"/>
+          <Option type="QString" value="0.25;253,174,97,255;rgb;ccw:0.5;255,255,191,255;rgb;ccw:0.75;171,221,164,255;rgb;ccw" name="stops"/>
+        </Option>
+      </colorramp>
+    </rasterrenderer>
+    <brightnesscontrast contrast="0" gamma="1" brightness="0"/>
+    <huesaturation colorizeOn="0" colorizeStrength="100" saturation="0" colorizeBlue="128" colorizeGreen="128" invertColors="0" colorizeRed="255" grayscaleMode="0"/>
+    <rasterresampler maxOversampling="2"/>
+    <resamplingStage>resamplingFilter</resamplingStage>
+  </pipe>
+  <blendMode>0</blendMode>
+</qgis>

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -4311,7 +4311,7 @@
                         "{assets_dir}/latitude_shape_40_degrees.geojson",
                         "-crop_to_cutline",
                         "-r",
-                        "bilinear",
+                        "nearest",
                         "-t_srs",
                         "EPSG:3413",
                         "-tr",

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -237,6 +237,26 @@
         "title": "The distribution of thick-billed and common murre colonies in the North."
       }
     },
+    "circumpolar_arctic_vegetation_map": {
+      "assets": {
+        "only": {
+          "id": "only",
+          "urls": [
+            "https://data.mendeley.com/public-files/datasets/c4xj5rv6kv/files/5223c414-234a-498c-ae08-3100cb38510f/file_downloaded"
+          ],
+          "verify_tls": true
+        }
+      },
+      "id": "circumpolar_arctic_vegetation_map",
+      "metadata": {
+        "abstract": "Land cover maps are the basic data layer required for\nunderstanding and modeling ecological patterns and processes. The\nCircumpolar Arctic Vegetation Map (CAVM), produced in 2003, has been\nwidely used as a base map for studies in the arctic tundra\nbiome. However, the relatively coarse resolution and vector format\nof the map were not compatible with many other data sets. We present\na new version of the CAVM, building on the strengths of the original\nmap, while providing a finer spatial resolution, raster format, and\nimproved mapping. The Raster CAVM uses the legend, extent and\nprojection of the original CAVM. The legend has 16 vegetation types,\nglacier, saline water, freshwater, and non-arctic land. The Raster\nCAVM divides the original rock-water-vegetation complex map unit\nthat mapped the Canadian Shield into two map units, distinguishing\nbetween areas with lichen- and shrub-dominated vegetation. In\ncontrast to the original hand-drawn CAVM, the new map is based on\nunsupervised classifications of seventeen geographic/floristic\nsub-sections of the Arctic, using AVHRR and MODIS data (reflectance\nand NDVI) and elevation data. The units resulting from the\nclassification were modeled to the CAVM types using a wide variety\nof ancillary data. The map was reviewed by experts familiar with\ntheir particular region, including many of the original authors of\nthe CAVM from Canada, Greenland (Denmark), Iceland, Norway\n(including Svalbard), Russia, and the U.S. The analysis presented\nhere summarizes the area, geographical distribution, elevation,\nsummer temperatures, and NDVI of the map units. The greater spatial\nresolution of the Raster CAVM allowed more detailed mapping of\nwater-bodies and mountainous areas. It portrays coastal-inland\ngradients, and better reflects the heterogeneity of vegetation type\ndistribution than the original CAVM. Accuracy assessment of random\n1-km pixels interpreted from 6 Landsat scenes showed an average of\n70 % accuracy, up from 39 % for the original CAVM. The distribution\nof shrub-dominated types changed the most, with more prostrate shrub\ntundra mapped in mountainous areas, and less low shrub tundra in\nlowland areas. This improved mapping is important for quantifying\nexisting and potential changes to land cover, a key environmental\nindicator for modeling and monitoring ecosystems.\n\nRelated Publication:\n\nMartha K. Raynolds, Donald A. Walker, Andrew Balser, Christian Bay,\nMitch Campbell, Mikhail M. Cherosov, Fred J.A. Dani\u00ebls, Pernille\nBronken Eidesen, Ksenia A. Ermokhina, Gerald V. Frost, Birgit\nJedrzejek, M. Torre Jorgenson, Blair E. Kennedy, Sergei S. Kholod,\nIgor A. Lavrinenko, Olga V. Lavrinenko, Borg\u00fe\u00f3r Magn\u00fasson, Nadezhda\nV. Matveyeva, Sigmar Met\u00fasalemsson, Lennart Nilsen, Ian Olthof, Igor\nN. Pospelov, Elena B. Pospelova, Darren Pouliot, Vladimir Razzhivin,\nGabriela Schaepman-Strub, Jozef \u0160ib\u00edk, Mikhail Yu. Telyatnikov,\nElena Troeva, A raster version of the Circumpolar Arctic Vegetation\nMap (CAVM), Remote Sensing of Environment, Volume 232, 2019, 111297,\nISSN 0034-4257,\nhttps://doi.org/10.1016/j.rse.2019.111297. (https://www.sciencedirect.com/science/article/pii/S0034425719303165).",
+        "citation": {
+          "text": "Raynolds, Martha; Walker, Donald (2022), 'Raster Circumpolar\nArctic Vegetation Map', Mendeley Data, V2, doi:\n10.17632/c4xj5rv6kv.2",
+          "url": "https://data.mendeley.com/datasets/c4xj5rv6kv/2"
+        },
+        "title": "Raster Circumpolar Arctic Vegetation Map"
+      }
+    },
     "continental_shelf": {
       "assets": {
         "north_lines": {
@@ -4258,6 +4278,89 @@
                   "title": "Vegetation biomass 2010 (12.4km)"
                 },
                 "name": "vegetation_biomass_2010"
+              },
+              {
+                "layer_cfg": {
+                  "description": "Arctic vegetation classification raster.\n\nIndividual raster values are mapped to vegetation types as follows:\n\n'Raster Code': 'Vegetation Unit' - 'Short Description'\n1: B1 - Cryptogam, herb barren\n2: B2a - Cryptogam, barren complex\n3: B3 - Non-carbonate mountain complex\n4: B4 - Carbonate mountain complex\n5: B2b - Cryptogam, barren, dwarf-shrub complex\n21: G1 - Graminoid, forb, cryptogam tundra\n22: G2 - Graminoid, prostrate dwarf-shrub, forb, moss tundra\n23: G3 - Non-tussock sedge, dwarf-shrub, moss tundra\n24: G4 - Tussock-sedge, dwarf-shrub, moss tundra\n31: P1 - Prostrate dwarf-shrub, herb, lichen tundra\n32: P2 - Prostrate/hemi-prostrate dwarf-shrub, lichen tundra\n33: S1 - Erect dwarf-shrub, moss tundra\n34: S2 - Low-shrub, moss tundra\n41: W1 - Sedge/grass, moss wetland complex\n42: W2 - Sedge, moss, dwarf-shrub wetland complex\n43: W3 - Sedge, moss, low-shrub wetland complex\n91: FW - Fresh water\n92: SW - Saline water\n93: GL - Glacier\n99: NA - Non-Arctic\n\n Environmental and climatic conditions are\nextreme, with a short growing season and low summer temperatures. The\nregion support plants such as dwarf shrubs, herbs, lichens and mosses,\nwhich grow close to the ground. As one moves southward (outward from\nmap's center in all directions), the amount of warmth available for\nplant growth increases considerably, allowing the size, abundance, and\nvariety of plants to increase as well. Climate and other environmental\ncontrols, such as landscape, topography, soil chemistry, soil moisture,\nand the available plants that historically colonized an area, also\ninfluence the distribution of plant communities.\n\nFor more information, visit:\nhttps://www.geobotany.uaf.edu/cavm/abstract.php.",
+                  "id": "circumpolar_arctic_vegetation_map",
+                  "in_package": true,
+                  "input": {
+                    "asset": {
+                      "id": "only"
+                    },
+                    "dataset": {
+                      "id": "circumpolar_arctic_vegetation_map"
+                    }
+                  },
+                  "show": false,
+                  "steps": [
+                    {
+                      "args": [
+                        "unzip",
+                        "{input_dir}/Raster\\ CAVM\\ GIS\\ data.zip",
+                        "-d",
+                        "{output_dir}",
+                        ""
+                      ],
+                      "type": "command"
+                    },
+                    {
+                      "args": [
+                        "gdalwarp",
+                        "-cutline",
+                        "{assets_dir}/latitude_shape_40_degrees.geojson",
+                        "-crop_to_cutline",
+                        "-r",
+                        "bilinear",
+                        "-t_srs",
+                        "EPSG:3413",
+                        "-tr",
+                        "1000",
+                        "1000",
+                        "-co",
+                        "COMPRESS=DEFLATE",
+                        "{input_dir}/raster_cavm_v1.tif",
+                        "{output_dir}/warped.tif"
+                      ],
+                      "type": "command"
+                    },
+                    {
+                      "args": [
+                        "gdal_translate",
+                        "-co",
+                        "TILED=YES",
+                        "-co",
+                        "COMPRESS=DEFLATE",
+                        "-co",
+                        "PREDICTOR=2",
+                        "{input_dir}/warped.tif",
+                        "{output_dir}/compressed.tif"
+                      ],
+                      "type": "command"
+                    },
+                    {
+                      "args": [
+                        "cp",
+                        "{input_dir}/compressed.tif",
+                        "{output_dir}/compressed.tif",
+                        "&&",
+                        "gdaladdo",
+                        "-r",
+                        "average",
+                        "{output_dir}/compressed.tif",
+                        "2",
+                        "4",
+                        "8",
+                        "16"
+                      ],
+                      "type": "command"
+                    }
+                  ],
+                  "style": "arctic_vegetation",
+                  "tags": [],
+                  "title": "Vegetation classification map (1km)"
+                },
+                "name": "circumpolar_arctic_vegetation_map"
               }
             ],
             "name": "Vegetation",

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -4346,7 +4346,7 @@
                         "&&",
                         "gdaladdo",
                         "-r",
-                        "average",
+                        "mode",
                         "{output_dir}/compressed.tif",
                         "2",
                         "4",

--- a/qgreenland/config/datasets/circumpolar_arctic_vegetation_map.py
+++ b/qgreenland/config/datasets/circumpolar_arctic_vegetation_map.py
@@ -1,0 +1,81 @@
+from qgreenland.models.config.asset import HttpAsset
+from qgreenland.models.config.dataset import Dataset
+
+circumpolar_arctic_vegetation_map = Dataset(
+    id="circumpolar_arctic_vegetation_map",
+    assets=[
+        HttpAsset(
+            id="only",
+            urls=[
+                (
+                    "https://data.mendeley.com/public-files/datasets/c4xj5rv6kv/files/5223c414-234a-498c-ae08-3100cb38510f/file_downloaded"
+                ),
+            ],
+        ),
+    ],
+    metadata={
+        "title": "Raster Circumpolar Arctic Vegetation Map",
+        "abstract": (
+            """Land cover maps are the basic data layer required for
+            understanding and modeling ecological patterns and processes. The
+            Circumpolar Arctic Vegetation Map (CAVM), produced in 2003, has been
+            widely used as a base map for studies in the arctic tundra
+            biome. However, the relatively coarse resolution and vector format
+            of the map were not compatible with many other data sets. We present
+            a new version of the CAVM, building on the strengths of the original
+            map, while providing a finer spatial resolution, raster format, and
+            improved mapping. The Raster CAVM uses the legend, extent and
+            projection of the original CAVM. The legend has 16 vegetation types,
+            glacier, saline water, freshwater, and non-arctic land. The Raster
+            CAVM divides the original rock-water-vegetation complex map unit
+            that mapped the Canadian Shield into two map units, distinguishing
+            between areas with lichen- and shrub-dominated vegetation. In
+            contrast to the original hand-drawn CAVM, the new map is based on
+            unsupervised classifications of seventeen geographic/floristic
+            sub-sections of the Arctic, using AVHRR and MODIS data (reflectance
+            and NDVI) and elevation data. The units resulting from the
+            classification were modeled to the CAVM types using a wide variety
+            of ancillary data. The map was reviewed by experts familiar with
+            their particular region, including many of the original authors of
+            the CAVM from Canada, Greenland (Denmark), Iceland, Norway
+            (including Svalbard), Russia, and the U.S. The analysis presented
+            here summarizes the area, geographical distribution, elevation,
+            summer temperatures, and NDVI of the map units. The greater spatial
+            resolution of the Raster CAVM allowed more detailed mapping of
+            water-bodies and mountainous areas. It portrays coastal-inland
+            gradients, and better reflects the heterogeneity of vegetation type
+            distribution than the original CAVM. Accuracy assessment of random
+            1-km pixels interpreted from 6 Landsat scenes showed an average of
+            70 % accuracy, up from 39 % for the original CAVM. The distribution
+            of shrub-dominated types changed the most, with more prostrate shrub
+            tundra mapped in mountainous areas, and less low shrub tundra in
+            lowland areas. This improved mapping is important for quantifying
+            existing and potential changes to land cover, a key environmental
+            indicator for modeling and monitoring ecosystems.
+
+            Related Publication:
+
+            Martha K. Raynolds, Donald A. Walker, Andrew Balser, Christian Bay,
+            Mitch Campbell, Mikhail M. Cherosov, Fred J.A. Daniëls, Pernille
+            Bronken Eidesen, Ksenia A. Ermokhina, Gerald V. Frost, Birgit
+            Jedrzejek, M. Torre Jorgenson, Blair E. Kennedy, Sergei S. Kholod,
+            Igor A. Lavrinenko, Olga V. Lavrinenko, Borgþór Magnússon, Nadezhda
+            V. Matveyeva, Sigmar Metúsalemsson, Lennart Nilsen, Ian Olthof, Igor
+            N. Pospelov, Elena B. Pospelova, Darren Pouliot, Vladimir Razzhivin,
+            Gabriela Schaepman-Strub, Jozef Šibík, Mikhail Yu. Telyatnikov,
+            Elena Troeva, A raster version of the Circumpolar Arctic Vegetation
+            Map (CAVM), Remote Sensing of Environment, Volume 232, 2019, 111297,
+            ISSN 0034-4257,
+            https://doi.org/10.1016/j.rse.2019.111297. (https://www.sciencedirect.com/science/article/pii/S0034425719303165).
+            """
+        ),
+        "citation": {
+            "text": (
+                """Raynolds, Martha; Walker, Donald (2022), 'Raster Circumpolar
+                Arctic Vegetation Map', Mendeley Data, V2, doi:
+                10.17632/c4xj5rv6kv.2"""
+            ),
+            "url": "https://data.mendeley.com/datasets/c4xj5rv6kv/2",
+        },
+    },
+)

--- a/qgreenland/config/layers/Biology/Vegetation/vegetation_map.py
+++ b/qgreenland/config/layers/Biology/Vegetation/vegetation_map.py
@@ -67,6 +67,7 @@ circumpolar_arctic_vegetation_map_layer = Layer(
             input_file="{input_dir}/raster_cavm_v1.tif",
             output_file="{output_dir}/warped.tif",
             cut_file=project.boundaries["background"].filepath,
+            resampling_method="nearest",
             warp_args=(
                 "-tr",
                 "1000",

--- a/qgreenland/config/layers/Biology/Vegetation/vegetation_map.py
+++ b/qgreenland/config/layers/Biology/Vegetation/vegetation_map.py
@@ -1,0 +1,82 @@
+from qgreenland.config.datasets.circumpolar_arctic_vegetation_map import (
+    circumpolar_arctic_vegetation_map as dataset,
+)
+from qgreenland.config.helpers.steps.compress_and_add_overviews import (
+    compress_and_add_overviews,
+)
+from qgreenland.config.helpers.steps.decompress import decompress_step
+from qgreenland.config.helpers.steps.warp import warp
+from qgreenland.config.project import project
+from qgreenland.models.config.layer import Layer, LayerInput
+
+circumpolar_arctic_vegetation_map_layer = Layer(
+    id="circumpolar_arctic_vegetation_map",
+    title="Vegetation classification map (1km)",
+    description=(
+        """Arctic vegetation classification raster.
+
+            Individual raster values are mapped to vegetation types as follows:
+
+            'Raster Code': 'Vegetation Unit' - 'Short Description'
+            1: B1 - Cryptogam, herb barren
+            2: B2a - Cryptogam, barren complex
+            3: B3 - Non-carbonate mountain complex
+            4: B4 - Carbonate mountain complex
+            5: B2b - Cryptogam, barren, dwarf-shrub complex
+            21: G1 - Graminoid, forb, cryptogam tundra
+            22: G2 - Graminoid, prostrate dwarf-shrub, forb, moss tundra
+            23: G3 - Non-tussock sedge, dwarf-shrub, moss tundra
+            24: G4 - Tussock-sedge, dwarf-shrub, moss tundra
+            31: P1 - Prostrate dwarf-shrub, herb, lichen tundra
+            32: P2 - Prostrate/hemi-prostrate dwarf-shrub, lichen tundra
+            33: S1 - Erect dwarf-shrub, moss tundra
+            34: S2 - Low-shrub, moss tundra
+            41: W1 - Sedge/grass, moss wetland complex
+            42: W2 - Sedge, moss, dwarf-shrub wetland complex
+            43: W3 - Sedge, moss, low-shrub wetland complex
+            91: FW - Fresh water
+            92: SW - Saline water
+            93: GL - Glacier
+            99: NA - Non-Arctic
+
+             Environmental and climatic conditions are
+            extreme, with a short growing season and low summer temperatures. The
+            region support plants such as dwarf shrubs, herbs, lichens and mosses,
+            which grow close to the ground. As one moves southward (outward from
+            map's center in all directions), the amount of warmth available for
+            plant growth increases considerably, allowing the size, abundance, and
+            variety of plants to increase as well. Climate and other environmental
+            controls, such as landscape, topography, soil chemistry, soil moisture,
+            and the available plants that historically colonized an area, also
+            influence the distribution of plant communities.
+
+            For more information, visit:
+            https://www.geobotany.uaf.edu/cavm/abstract.php."""
+    ),
+    tags=[],
+    style="arctic_vegetation",
+    input=LayerInput(
+        dataset=dataset,
+        asset=dataset.assets["only"],
+    ),
+    steps=[
+        decompress_step(
+            input_file="{input_dir}/Raster\\ CAVM\\ GIS\\ data.zip",
+        ),
+        *warp(
+            input_file="{input_dir}/raster_cavm_v1.tif",
+            output_file="{output_dir}/warped.tif",
+            cut_file=project.boundaries["background"].filepath,
+            warp_args=(
+                "-tr",
+                "1000",
+                "1000",
+            ),
+        ),
+        *compress_and_add_overviews(
+            input_file="{input_dir}/warped.tif",
+            output_file="{output_dir}/compressed.tif",
+            dtype_is_float=False,
+        ),
+    ],
+)

--- a/qgreenland/config/layers/Biology/Vegetation/vegetation_map.py
+++ b/qgreenland/config/layers/Biology/Vegetation/vegetation_map.py
@@ -77,6 +77,7 @@ circumpolar_arctic_vegetation_map_layer = Layer(
         *compress_and_add_overviews(
             input_file="{input_dir}/warped.tif",
             output_file="{output_dir}/compressed.tif",
+            resampling_algorithm="mode",
             dtype_is_float=False,
         ),
     ],


### PR DESCRIPTION
## Description

Add layer from the Raster Circumpolar Arctic Vegetation Map produced by [Raynolds et al., 2019](https://www.sciencedirect.com/science/article/pii/S0034425719303165?via%3Dihub#s0095).

The data came with a csv file mapping raster data values to categories and descriptions of those categories. The included style (`arctic_vegetation.qml`) labels each entry appropriately. Moreover, I  tried to match the colors used in the publication as closely as possible, by extracting color codes from this jpg: https://ars.els-cdn.com/content/image/1-s2.0-S0034425719303165-gr1_lrg.jpg

I also included mapping of raster data values to categories in the layer description for quick reference.

## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
