### PR TITLE
ON HOLD - init config for CALM sites layer

### DIFF
--- a/qgreenland/config/datasets/circumpolar_active_layer_monitoring.py
+++ b/qgreenland/config/datasets/circumpolar_active_layer_monitoring.py
@@ -1,0 +1,47 @@
+from qgreenland.models.config.asset import HttpAsset
+from qgreenland.models.config.dataset import Dataset
+
+circumpolar_layer_monitoring = Dataset(
+    id="circumpolar_layer_monitoring",
+    assets=[
+        HttpAsset(
+            id="only",
+            urls=[
+                "https://www2.gwu.edu/~calm/data/CALM_Sites_wData.7z",
+            ],
+        ),
+    ],
+    metadata={
+        "title": "Circumpolar Active Layer Monitoring Network-CALM: Long-Term Observations of the Climate-Active Layer-Permafrost System",
+        "abstract": (
+            """The primary goal of the Circumpolar Active Layer Monitoring
+            (CALM) program is to observe the response of the active layer and
+            near-surface permafrost to climate change over long (multi-decadal)
+            time scales. The CALM observational network, established in the
+            1990s, observes the long-term response of the active layer and
+            near-surface permafrost to changes and variations in climate at more
+            than 200 sites in both hemispheres. CALM currently has participants
+            from 15 countries. Majority of sites measure active-layer thickness
+            on grids ranging from 1 ha to 1 km², and observe soil
+            temperatures. Most sites in the CALM network are located in Arctic
+            and Subarctic lowlands. Southern Hemisphere component (CALM-South)
+            is being organized and currently includes sites in Antarctic and
+            South America. The broader impacts of this project are derived from
+            the hypothesis that widespread, systematic changes in the thickness
+            of the active layer could have profound effects on the flux of
+            greenhouse gases, on the human infrastructure in cold regions, and
+            on landscape processes. It is therefore critical that observational
+            and analytical procedures continue over decadal periods to assess
+            trends and detect cumulative, long-term changes.
+
+            The CALM program began in 1991. It was initially affiliated with the
+            International Tundra Experiment and has been supported independently and
+            continuously since 1998 through grants from the U.S. National Science
+            Foundation*. CALM is funded by the NSF Project OPP-1836377."""
+        ),
+        "citation": {
+            "text": ("""TODO..."""),
+            "url": "https://www2.gwu.edu/~calm/data/north.htm",
+        },
+    },
+)

--- a/qgreenland/config/layers/Frozen ground/layers.py
+++ b/qgreenland/config/layers/Frozen ground/layers.py
@@ -1,9 +1,14 @@
+from qgreenland.config.datasets.circumpolar_active_layer_monitoring import (
+    circumpolar_layer_monitoring,
+)
 from qgreenland.config.datasets.pangaea_ground_temperature import (
     pangaea_ground_temperature as dataset,
 )
 from qgreenland.config.helpers.steps.compress_and_add_overviews import (
     compress_and_add_overviews,
 )
+from qgreenland.config.helpers.steps.decompress import decompress_step
+from qgreenland.config.helpers.steps.ogr2ogr import ogr2ogr
 from qgreenland.config.helpers.steps.warp_and_cut import warp_and_cut
 from qgreenland.config.project import project
 from qgreenland.models.config.layer import Layer, LayerInput
@@ -36,7 +41,7 @@ _layer_params = {
 }
 
 
-layers = [
+pangaea_layers = [
     Layer(
         id=layer_id,
         title=params["title"],
@@ -85,3 +90,28 @@ layers = [
     )
     for layer_id, params in _layer_params.items()
 ]
+
+
+calm_layer = Layer(
+    id="calm_network_sites",
+    title="CALM network sites",
+    description="""TODO...""",
+    tags=[],
+    style=None,
+    input=LayerInput(
+        dataset=circumpolar_layer_monitoring,
+        asset=circumpolar_layer_monitoring.assets["only"],
+    ),
+    steps=[
+        decompress_step(
+            input_file="{input_dir}/CALM_Sites_wData.7z", decompress_type="7z"
+        ),
+        *ogr2ogr(
+            input_file="{input_dir}/CALM_SitesData.shp",
+            output_file="{output_dir}/calm_sites_data.gpkg",
+            # Some features fall outside of our project CRS so an error is
+            # raised without `skipfailures`.
+            ogr2ogr_args=("-skipfailures",),
+        ),
+    ],
+)


### PR DESCRIPTION
## Description

Add Circumpolar Active Layer Monitoring (CALM) Network sites layer. It was recommended that we look at this data by [Christina Schaedel](https://www.woodwellclimate.org/staff/christina-schaedel/).

This data is provided in a few different formats: a `kml` (Google Earth format) file that does not seem to contain useful attribute information, a 7-zipped shapefile that contains useful (but incomplete/misleading) attributes, and a microsoft xls document that appears to contain all of the data.

This PR adds data from the Shapefile. It has some issues:

* It encodes missing data as 0, which could be a valid value
* Attribute names are not correct. There is a column for each year from 1990-2022 in the excel spreadsheet but in the shapefile each of these columns is named "F8" - "F32" (F8 is 1990 and F32 is 2022).
* There may be missing information about the type of measurement each record represents. The spreadsheet uses color as a label (e.g., red-highlighted records represent sites that use "spatially-oriented mechanical probing at regular intervals across a grid" while blue sites use "thaw-tube measurements".

Unfortunately the excel spreadsheet has headers/multiple sections and would probably require a Python script to completely parse out. ~~Given that there are no sites in Greenland,~~ maybe we should hold off on this layer and consider others first.

## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [ ] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [ ] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [ ] CHANGELOG.md updated
- [ ] Documentation updated if needed
- [ ] New unit tests if needed
