### PR TITLE
Fixup hydrologic outlets/basins layers descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * QGreenland Custom is no longer supported.
 * Remove "Biology/Fish/Arctic Char" layer.
+* Fix descriptions of "Hydrology" outlets and basins layers.
 
 
 # v3.0.0alpha3 (2023-07-05)

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -18672,7 +18672,7 @@
           },
           {
             "layer_cfg": {
-              "description": "Calculated locations for subglacial hydrologic basin\nice-margin-terminating outlets.",
+              "description": "Calculated locations for subglacial hydrologic basin ice-margin-terminating outlets.",
               "id": "ice_outlets",
               "in_package": true,
               "input": {
@@ -18709,7 +18709,7 @@
           },
           {
             "layer_cfg": {
-              "description": "Calculated locations for subglacial hydrologic basin\nice-margin-terminating outlets.",
+              "description": "Calculated locations for terrestrial hydrologic basin coast-terminating outlets.",
               "id": "land_outlets",
               "in_package": true,
               "input": {
@@ -18746,7 +18746,7 @@
           },
           {
             "layer_cfg": {
-              "description": "Calculated locations for subglacial hydrologic basin\nice-margin-terminating outlets.",
+              "description": "Calculated subglacial hydrologic stream paths.",
               "id": "ice_streams",
               "in_package": true,
               "input": {
@@ -18787,7 +18787,7 @@
           },
           {
             "layer_cfg": {
-              "description": "Calculated locations for subglacial hydrologic basin\nice-margin-terminating outlets.",
+              "description": "Calculated ice sheet hydrologic basins using regional climate model spatial coverage.",
               "id": "ice_basins",
               "in_package": true,
               "input": {
@@ -18824,7 +18824,7 @@
           },
           {
             "layer_cfg": {
-              "description": "Calculated locations for subglacial hydrologic basin\nice-margin-terminating outlets.",
+              "description": "Calculated ice sheet hydrologic basins including areas classified as land/ocean by regional climate models (filled).",
               "id": "ice_basins_filled",
               "in_package": true,
               "input": {
@@ -18861,7 +18861,7 @@
           },
           {
             "layer_cfg": {
-              "description": "Calculated locations for subglacial hydrologic basin\nice-margin-terminating outlets.",
+              "description": "Calculated terrestrial hydrologic stream paths.",
               "id": "land_streams",
               "in_package": true,
               "input": {
@@ -18902,7 +18902,7 @@
           },
           {
             "layer_cfg": {
-              "description": "Calculated locations for subglacial hydrologic basin\nice-margin-terminating outlets.",
+              "description": "Calculated terrestrial hydrologic basins using regional climate model spatial coverage.",
               "id": "land_basins",
               "in_package": true,
               "input": {
@@ -18939,7 +18939,7 @@
           },
           {
             "layer_cfg": {
-              "description": "Calculated locations for subglacial hydrologic basin\nice-margin-terminating outlets.",
+              "description": "Calculated terrestrial hydrologic basins including areas classified as ice/ocean by regional climate models (filled).",
               "id": "land_basins_filled",
               "in_package": true,
               "input": {

--- a/qgreenland/config/helpers/layers/streams_outlets_basins.py
+++ b/qgreenland/config/helpers/layers/streams_outlets_basins.py
@@ -71,10 +71,7 @@ layers = [
     Layer(
         id=layer_id,
         title=layer_id.replace("_", " ").capitalize(),
-        description=(
-            """Calculated locations for subglacial hydrologic basin
-            ice-margin-terminating outlets."""
-        ),
+        description=params["description"],
         tags=[],
         style=layer_id.replace("_filled", ""),
         input=LayerInput(


### PR DESCRIPTION
## Description

The description was incorrectly hard-coded for all hydrologic outlet/basins layers except "Ice outlets".

Apply descriptions in existing layer params dict to each layer object. :man_facepalming: 


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
