### PR TITLE
Add GTN-P reference layers: CALM and TSP sites

### DIFF
--- a/qgreenland/config/datasets/gtn_permafrost.py
+++ b/qgreenland/config/datasets/gtn_permafrost.py
@@ -1,0 +1,39 @@
+from qgreenland.models.config.asset import HttpAsset
+from qgreenland.models.config.dataset import Dataset
+
+gtn_permafrost = Dataset(
+    id="gtn_permafrost",
+    assets=[
+        HttpAsset(
+            id="boreholes",
+            urls=[
+                "http://flatey.arcticportal.org:8080/geoserver/page21/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=page21:tsp&maxFeatures=3000&outputFormat=CSV",
+            ],
+        ),
+        HttpAsset(
+            id="calm_sites",
+            urls=[
+                "https://gtnp.arcticportal.org/images/downloads/calm.csv",
+            ],
+        ),
+    ],
+    metadata={
+        "title": "Global Terrestrial Network for Permafrost (GTN-P)",
+        "abstract": (
+            """The Global Terrestrial Network for Permafrost (GTN-P) is the
+            primary international programme concerned with monitoring permafrost
+            parameters. GTN-P was developed by the International Permafrost
+            Association (IPA) under the Global Climate Observing System (GCOS)
+            and the Global Terrestrial Observing Network (GTOS) in 1999, with
+            the long term goal of obtaining a comprehensive view of the spatial
+            structure, trends, and variability of changes in the active layer
+            thickness and permafrost temperature."""
+        ),
+        "citation": {
+            "text": (
+                """Global Terrestrial Network for Permafrost. Date accessed: {{date_accessed}}."""
+            ),
+            "url": "https://gtnp.arcticportal.org/",
+        },
+    },
+)


### PR DESCRIPTION
## Description

These would be nice reference layers, but the GTN-P [data policy](https://gtnp.arcticportal.org/data/15-data/database/15-data-policies) states:

> Downloaded data cannot be redistributed to others and must not be redistributed via other websites, databases r any other storage system to prevent circulation of different versions of the datasets.

An understandable concern, but since these are primarily refernece layres that point to the actual timeseries data (except for the CALM layer, see below), maybe these would be allowed. We could reach out to the maintainers of the GTN-P database to get their approval if we feel strongly about it.

The CALM layer is the only one that seems to contain actual data (1990-2017). This layer seems to mirror the data on the [CALM](https://www2.gwu.edu/~calm/data/north.htm) site, but is older.

## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [ ] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [ ] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [ ] CHANGELOG.md updated
- [ ] Documentation updated if needed
- [ ] New unit tests if needed
