### PR TITLE
Add new cryo-generated seismic events layer

### DIFF
--- a/qgreenland/config/datasets/geus.py
+++ b/qgreenland/config/datasets/geus.py
@@ -1,0 +1,42 @@
+from qgreenland.models.config.asset import HttpAsset
+from qgreenland.models.config.dataset import Dataset
+
+geus_cryo_seismic_events = Dataset(
+    id="geus_cryo_seismic_events",
+    assets=[
+        HttpAsset(
+            id="only",
+            urls=[
+                "https://seis.geus.net/quakes/cryo.lis",
+            ],
+        ),
+    ],
+    metadata={
+        "title": "Cryo-generated Seismic Events in Greenland",
+        "abstract": (
+            """Parametric data from cryo-generated seismic events in Greenland,
+            detected, processed and analysed at the Geological Survey of Denmark
+            and Greenland – GEUS, using data from the earthquake monitoring
+            network. Daily updates of the data is available via the URL
+            https://seis.geus.net/quakes/cryo.lis for a simple CSV listing of
+            event time and location, given by date and UTC time and latitude and
+            longitude (WGS 84). Or via the URL
+            https://seis.geus.net/quakes/cryo.nor for the complete set of
+            parametric data available in the event database at GEUS. Here the
+            data are given in the Nordic format, described in appendix A of the
+            SEISAN manual (Ottemöller et al. 2021). REF: Ottemöller, L., Voss,
+            P.H. and Havskov J. (2021). SEISAN Earthquake Analysis Software for
+            Windows, Solaris, Linux and Macosx, Version 12.0. 607 pp. University
+            of Bergen. ISBN 978-82-8088-501-2. (2022-03-18)."""
+        ),
+        "citation": {
+            "text": (
+                """Voss, Peter H. and Dahl-Jensen, Trine and Larsen, Tine B. and Rinds, Nicoali, 2022,
+                "Cryo-generated Seismic Events in Greenland, V1", GEUS Dataverse.
+
+                Date accessed: {{date_accessed}}."""
+            ),
+            "url": "https://doi.org/10.22008/FK2/ABMBLO",
+        },
+    },
+)

--- a/qgreenland/config/layers/Geology/__settings__.py
+++ b/qgreenland/config/layers/Geology/__settings__.py
@@ -6,6 +6,7 @@ from qgreenland.models.config.layer_group import (
 
 settings = LayerGroupSettings(
     order=[
+        LayerIdentifier("cryo_seismic_events"),
         LayerIdentifier("earthquakes"),
         LayerIdentifier("tectonic_plate_boundaries"),
         LayerIdentifier("tectonic_plate_polygons"),

--- a/qgreenland/config/layers/Geology/earthquakes.py
+++ b/qgreenland/config/layers/Geology/earthquakes.py
@@ -1,4 +1,5 @@
 from qgreenland.config.datasets.earthquakes import earthquakes as dataset
+from qgreenland.config.datasets.geus import geus_cryo_seismic_events
 from qgreenland.config.helpers.steps.ogr2ogr import ogr2ogr
 from qgreenland.config.project import project
 from qgreenland.models.config.layer import Layer, LayerInput
@@ -62,6 +63,62 @@ earthquakes = Layer(
                     title,
                     title as label
                 FROM merged\"""",
+            ),
+        ),
+    ],
+)
+
+cryo_seismic_events = Layer(
+    id="cryo_seismic_events",
+    title="Cryo-generated seismic events",
+    description=(
+        """Cryo-generated seismic events.
+
+The datetime of each event is given in UTC. For additional data on each event,
+see
+https://dataverse.geus.dk/dataset.xhtml?persistentId=doi:10.22008/FK2/ABMBLO"""
+    ),
+    tags=[],
+    # TODO:
+    style=None,
+    input=LayerInput(
+        dataset=geus_cryo_seismic_events,
+        asset=geus_cryo_seismic_events.assets["only"],
+    ),
+    steps=[
+        CommandStep(
+            id="create_source",
+            args=[
+                'echo "datetime; lat; lon" > {output_dir}/cryo_with_header.csv',
+                "&&",
+                "cat {input_dir}/cryo.lis >> {output_dir}/cryo_with_header.csv",
+            ],
+        ),
+        *ogr2ogr(
+            input_file="{input_dir}/cryo_with_header.csv",
+            output_file="{output_dir}/cryo_events.gpkg",
+            boundary_filepath=project.boundaries["background"].filepath,
+            ogr2ogr_args=(
+                "-s_srs",
+                "EPSG:4326",
+                "-oo",
+                "X_POSSIBLE_NAMES=lon",
+                "-oo",
+                "Y_POSSIBLE_NAMES=lat",
+            ),
+        ),
+        *ogr2ogr(
+            input_file="{input_dir}/cryo_events.gpkg",
+            output_file="{output_dir}/cryo_events_with_datetime.gpkg",
+            boundary_filepath=project.boundaries["background"].filepath,
+            ogr2ogr_args=(
+                "-dialect",
+                "sqlite",
+                "-sql",
+                """\"SELECT
+                geom,
+                substr(datetime, 1, 4) || '-' || substr(datetime, 6, 2) || '-' || substr(datetime, 8, 2) || 'T' || substr(datetime, 11, 2) || ':' || substr(datetime, 13, 2) as datetime
+                FROM cryo_with_header\"""",
             ),
         ),
     ],


### PR DESCRIPTION
## Description

Title. This dataset comes from the GEUS Dataverse: Cryo-generated Seismic Events in Greenland](https://dataverse.geus.dk/dataset.xhtml?persistentId=doi:10.22008/FK2/ABMBLO). As currently configured, this layer is derived from a text file (`;` delimited) that **only includes datetime and location** of seismic events. A user would need to look at the other data in the Dataverse dataset to know more about these events.


## Checklist

If an item on this list is done _or not needed_, simply check it with `[x]`.

- [ ] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [ ] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build`)
- [ ] CHANGELOG.md updated
- [ ] Documentation updated if needed
- [ ] New unit tests if needed
