### PR TITLE
Cleanup OBE references to `gdal_remote` and "Online" QgsLayerType

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,6 @@ checkbox.
 - [ ] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
 - [ ] Environment lockfile updated if needed (`conda-lock`)
 - [ ] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build)`)
-- [ ] CHANGELOG.md updated
+- [ ] CHANGELOG.md updated (for user-facing changes)
 - [ ] Documentation updated if needed
 - [ ] New unit tests if needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   places" layer. Scale point markers for this layer by population.
 * Add new "Internet-required data/Geological Map (1:500 000)" layer from GEUS.
 * Add new "Geology/Mineral occurrences" layer from GEUS.
+* Remove OBE references to "gdal_remote" layers. Remove "Online" from `QgsLayerType`.
 
 
 # v3.0.0alpha4 (2023-07-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   places" layer. Scale point markers for this layer by population.
 * Add new "Internet-required data/Geological Map (1:500 000)" layer from GEUS.
 * Add new "Geology/Mineral occurrences" layer from GEUS.
+* Update `layer_list.csv` to include new column indicating if each layer is
+  stored on disk. Internet-required layers take the value `False`.
 
 
 # v3.0.0alpha4 (2023-07-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
   places" layer. Scale point markers for this layer by population.
 * Add new "Internet-required data/Geological Map (1:500 000)" layer from GEUS.
 * Add new "Geology/Mineral occurrences" layer from GEUS.
-* Remove OBE references to "gdal_remote" layers. Remove "Online" from `QgsLayerType`.
 
 
 # v3.0.0alpha4 (2023-07-21)

--- a/qgreenland/_typing.py
+++ b/qgreenland/_typing.py
@@ -5,7 +5,7 @@ NOTE: This module is named strangely to avoid conflicts with the stdlib's
 """
 from typing import Literal, Union
 
-QgsLayerType = Literal["Vector", "Raster"]
+VectorOrRaster = Literal["Vector", "Raster"]
 QgsLayerProviderType = Literal["gdal", "ogr", "wms", "wfs", "wcs"]
 
 ResamplingMethod = Literal["bilinear", "nearest"]

--- a/qgreenland/_typing.py
+++ b/qgreenland/_typing.py
@@ -5,7 +5,7 @@ NOTE: This module is named strangely to avoid conflicts with the stdlib's
 """
 from typing import Literal, Union
 
-QgsLayerType = Literal["Vector", "Raster", "Online"]
+QgsLayerType = Literal["Vector", "Raster"]
 QgsLayerProviderType = Literal["gdal", "ogr", "wms", "wfs", "wcs"]
 
 ResamplingMethod = Literal["bilinear", "nearest"]

--- a/qgreenland/constants/misc.py
+++ b/qgreenland/constants/misc.py
@@ -1,6 +1,6 @@
-from qgreenland._typing import QgsLayerProviderType, QgsLayerType
+from qgreenland._typing import QgsLayerProviderType, VectorOrRaster
 
-PROVIDER_LAYERTYPE_MAPPING: dict[QgsLayerProviderType, QgsLayerType] = {
+PROVIDER_VECTOR_OR_RASTER_MAPPING: dict[QgsLayerProviderType, VectorOrRaster] = {
     "gdal": "Raster",
     "wms": "Raster",
     "wfs": "Vector",

--- a/qgreenland/models/config/asset.py
+++ b/qgreenland/models/config/asset.py
@@ -44,9 +44,7 @@ class HttpAsset(DatasetAsset):
         return f"# Data fetched via HTTP from {[str(u) for u in self.urls]}"
 
 
-# TODO: OnlineRaster/OnlineVector asset types? The thing that makes this a
-# "gdal_remote" layer is the `/vsicurl/` prefix. Otherwise, this is created as a
-# regular layer with a URL as its path.
+# TODO: OnlineRaster/OnlineVector asset types?
 class OnlineAsset(DatasetAsset):
     """A QGIS online layer that is not fetched, but is accessed by QGIS."""
 

--- a/qgreenland/test/util/config/test_config_export.py
+++ b/qgreenland/test/util/config/test_config_export.py
@@ -118,7 +118,7 @@ def test_export_config_csv(full_cfg):
             **common,
             "Layer Title": "Example online",
             "Vector or Raster": "Raster",
-            "Layer Data On Disk": "False",
+            "Internet Required?": "False",
         },
         {
             **common,
@@ -126,7 +126,7 @@ def test_export_config_csv(full_cfg):
             "Vector or Raster": "Raster",
             "Layer Size": "619 Bytes",
             "Layer Size Bytes": "619",
-            "Layer Data On Disk": "True",
+            "Internet Required?": "True",
         },
     ]
 

--- a/qgreenland/test/util/config/test_config_export.py
+++ b/qgreenland/test/util/config/test_config_export.py
@@ -117,7 +117,8 @@ def test_export_config_csv(full_cfg):
         {
             **common,
             "Layer Title": "Example online",
-            "Vector or Raster": "Online",
+            "Vector or Raster": "Raster",
+            "Layer Data On Disk": "False",
         },
         {
             **common,
@@ -125,6 +126,7 @@ def test_export_config_csv(full_cfg):
             "Vector or Raster": "Raster",
             "Layer Size": "619 Bytes",
             "Layer Size Bytes": "619",
+            "Layer Data On Disk": "True",
         },
     ]
 

--- a/qgreenland/test/util/test_misc.py
+++ b/qgreenland/test/util/test_misc.py
@@ -9,5 +9,5 @@ def test_layer_compile_dir(raster_layer_node):
     assert expected == actual
 
 
-def test_vector_or_raster_gdal_remote(online_layer_node):
+def test_vector_or_raster(online_layer_node):
     assert layer_util.vector_or_raster(online_layer_node) == "Raster"

--- a/qgreenland/util/config/export.py
+++ b/qgreenland/util/config/export.py
@@ -85,8 +85,9 @@ def export_config_csv(
         vector_or_raster_data: VectorOrRaster
         layer_data_on_disk: bool
 
+        vector_or_raster_data = vector_or_raster(layer_node)
+
         if isinstance(layer_cfg.input.asset, OnlineAsset):
-            vector_or_raster_data = "Online"
             # Online layers have no size on disk.
             layer_size_bytes = 0
             layer_data_on_disk = False
@@ -94,7 +95,6 @@ def export_config_csv(
             layer_fp = get_layer_compile_filepath(layer_node)
             layer_dir = layer_fp.parent
             layer_size_bytes = directory_size_bytes(layer_dir)
-            vector_or_raster_data = vector_or_raster(layer_node)
             layer_data_on_disk = True
 
         dataset_cfg = layer_cfg.input.dataset

--- a/qgreenland/util/config/export.py
+++ b/qgreenland/util/config/export.py
@@ -83,19 +83,19 @@ def export_config_csv(
             continue
 
         vector_or_raster_data: VectorOrRaster
-        layer_data_on_disk: bool
+        internet_required: bool
 
         vector_or_raster_data = vector_or_raster(layer_node)
 
         if isinstance(layer_cfg.input.asset, OnlineAsset):
             # Online layers have no size on disk.
             layer_size_bytes = 0
-            layer_data_on_disk = False
+            internet_required = False
         else:
             layer_fp = get_layer_compile_filepath(layer_node)
             layer_dir = layer_fp.parent
             layer_size_bytes = directory_size_bytes(layer_dir)
-            layer_data_on_disk = True
+            internet_required = True
 
         dataset_cfg = layer_cfg.input.dataset
 
@@ -112,7 +112,7 @@ def export_config_csv(
                 "Data Source Citation URL": dataset_cfg.metadata.citation.url,
                 "Layer Size": naturalsize(layer_size_bytes),
                 "Layer Size Bytes": layer_size_bytes,
-                "Layer Data On Disk": layer_data_on_disk,
+                "Internet Required?": internet_required,
             }
         )
 

--- a/qgreenland/util/config/export.py
+++ b/qgreenland/util/config/export.py
@@ -8,7 +8,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
-from typing import Union
+from typing import Literal, Union
 
 from humanize import naturalsize
 
@@ -82,7 +82,9 @@ def export_config_csv(
         if not layer_cfg.in_package:
             continue
 
-        layer_type: QgsLayerType
+        # NOTE: we want to make it clear to users that some layers are "online"
+        # and we use the "Vector or Raster" column to do that.
+        layer_type: Union[QgsLayerType, Literal["Online"]]
         if isinstance(layer_cfg.input.asset, OnlineAsset):
             layer_type = "Online"
             # Online layers have no size on disk.

--- a/qgreenland/util/config/export.py
+++ b/qgreenland/util/config/export.py
@@ -12,7 +12,7 @@ from typing import Literal, Union
 
 from humanize import naturalsize
 
-from qgreenland._typing import QgsLayerType
+from qgreenland._typing import VectorOrRaster
 from qgreenland.models.config import Config
 from qgreenland.models.config.asset import OnlineAsset
 from qgreenland.util.fs import directory_contents, directory_size_bytes
@@ -84,7 +84,7 @@ def export_config_csv(
 
         # NOTE: we want to make it clear to users that some layers are "online"
         # and we use the "Vector or Raster" column to do that.
-        layer_type: Union[QgsLayerType, Literal["Online"]]
+        layer_type: Union[VectorOrRaster, Literal["Online"]]
         if isinstance(layer_cfg.input.asset, OnlineAsset):
             layer_type = "Online"
             # Online layers have no size on disk.

--- a/qgreenland/util/layer.py
+++ b/qgreenland/util/layer.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 import qgreenland.exceptions as exc
-from qgreenland._typing import QgsLayerType
-from qgreenland.constants.misc import PROVIDER_LAYERTYPE_MAPPING
+from qgreenland._typing import VectorOrRaster
+from qgreenland.constants.misc import PROVIDER_VECTOR_OR_RASTER_MAPPING
 from qgreenland.constants.paths import COMPILE_PACKAGE_DIR, RELEASE_LAYERS_DIR
 from qgreenland.models.config.asset import OnlineAsset
 from qgreenland.models.config.layer import Layer
@@ -10,10 +10,10 @@ from qgreenland.util.fs import get_layer_fp
 from qgreenland.util.tree import LayerNode
 
 
-def vector_or_raster(layer_node: LayerNode) -> QgsLayerType:
+def vector_or_raster(layer_node: LayerNode) -> VectorOrRaster:
     layer_cfg = layer_node.layer_cfg
     if type(layer_cfg.input.asset) is OnlineAsset:
-        return PROVIDER_LAYERTYPE_MAPPING[layer_cfg.input.asset.provider]
+        return PROVIDER_VECTOR_OR_RASTER_MAPPING[layer_cfg.input.asset.provider]
     else:
         layer_path = get_layer_compile_filepath(layer_node)
         return _vector_or_raster_from_fp(layer_path)
@@ -57,7 +57,7 @@ def _layer_dirname_from_cfg(layer_cfg: Layer) -> str:
     return layer_cfg.title
 
 
-def _vector_or_raster_from_fp(fp: Path) -> QgsLayerType:
+def _vector_or_raster_from_fp(fp: Path) -> VectorOrRaster:
     if fp.suffix == ".tif":
         return "Raster"
     elif fp.suffix == ".gpkg":


### PR DESCRIPTION
## Description

Title. Related to #655.

The handling of the term "online" is a bit messy. For example, we have a function called `vector_or_raster` that is typed to return one of "Raster", "Vector", or "Online", but our mapping from provider -> layer type doesn't include "Online", so `vector_or_raster` will only return what its function name indicates - "Vector" or "Raster".

The only place we appear to use the "Online" `QgsLayerType` is in the export code that produces the layer csv. This puts "Online" in the "Vector or Raster" column for online layers! That seems confusing. Maybe a separate field for "On disk" that is true/false would be a better indicator. Online assets are still either vectors or rasters!

This PR takes one step in the right direction by cleaning up OBE references to `gdal_remote` layers  and removes "Online" from the list of `QgsLayerType`s. Instead, add in the unique "Online" behavior where it's used - in the export code!

## Checklist

If an item on this list is done _or not needed_, check it with `[x]` or click the
checkbox.

- [x] The PR description links to issues that it resolves with `closes #{issue_number}`
- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Environment lockfile updated if needed (`conda-lock`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build)`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
