### PR TITLE
Buffer copyright text

### DIFF
--- a/qgreenland/util/qgis/project.py
+++ b/qgreenland/util/qgis/project.py
@@ -284,95 +284,10 @@ def _add_decorations(project: qgc.QgsProject) -> None:
     # buffer_settings = text_format.buffer()
     # buffer_settings.setEnabled(True)
     # text_format.setBuffer(buffer_settings)
-
     project.writeEntry(
         "CopyrightLabel",
         "/Font",
-        """<text-style multilineHeightUnit="Percentage" forcedItalic="0" namedStyle="Regular" forcedBold="0" capitalization="0" fontWeight="50" fontKerning="1" fontItalic="0" fontStrikeout="0" blendMode="0" fontWordSpacing="0" multilineHeight="1" fontSizeUnit="Point" textOrientation="horizontal" textColor="50,50,50,255" textOpacity="1" fontSize="10" fontSizeMapUnitScale="3x:0,0,0,0,0,0" previewBkgrdColor="255,255,255,255" allowHtml="0" fontFamily="Open Sans" fontLetterSpacing="0" fontUnderline="0">
- <families/>
- <text-buffer bufferColor="250,250,250,255" bufferJoinStyle="128" bufferSize="1" bufferDraw="1" bufferSizeUnits="MM" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferNoFill="1"/>
- <text-mask maskEnabled="0" maskOpacity="1" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSize="0" maskSizeUnits="MM" maskedSymbolLayers="" maskJoinStyle="128"/>
- <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="Point" shapeType="0" shapeDraw="0" shapeBlendMode="0" shapeSizeX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="Point" shapeOpacity="1" shapeRadiiX="0" shapeSizeType="0" shapeOffsetX="0" shapeRadiiUnit="Point" shapeRadiiY="0" shapeSVGFile="" shapeFillColor="255,255,255,255" shapeOffsetY="0" shapeOffsetUnit="Point" shapeRotationType="0" shapeRotation="0" shapeBorderColor="128,128,128,255" shapeJoinStyle="64" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidth="0">
-  <symbol force_rhr="0" clip_to_extent="1" is_animated="0" frame_rate="10" alpha="1" type="marker" name="markerSymbol">
-   <data_defined_properties>
-    <Option type="Map">
-     <Option type="QString" name="name" value=""/>
-     <Option name="properties"/>
-     <Option type="QString" name="type" value="collection"/>
-    </Option>
-   </data_defined_properties>
-   <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
-    <Option type="Map">
-     <Option type="QString" name="angle" value="0"/>
-     <Option type="QString" name="cap_style" value="square"/>
-     <Option type="QString" name="color" value="190,178,151,255"/>
-     <Option type="QString" name="horizontal_anchor_point" value="1"/>
-     <Option type="QString" name="joinstyle" value="bevel"/>
-     <Option type="QString" name="name" value="circle"/>
-     <Option type="QString" name="offset" value="0,0"/>
-     <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
-     <Option type="QString" name="offset_unit" value="MM"/>
-     <Option type="QString" name="outline_color" value="35,35,35,255"/>
-     <Option type="QString" name="outline_style" value="solid"/>
-     <Option type="QString" name="outline_width" value="0"/>
-     <Option type="QString" name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
-     <Option type="QString" name="outline_width_unit" value="MM"/>
-     <Option type="QString" name="scale_method" value="diameter"/>
-     <Option type="QString" name="size" value="2"/>
-     <Option type="QString" name="size_map_unit_scale" value="3x:0,0,0,0,0,0"/>
-     <Option type="QString" name="size_unit" value="MM"/>
-     <Option type="QString" name="vertical_anchor_point" value="1"/>
-    </Option>
-    <data_defined_properties>
-     <Option type="Map">
-      <Option type="QString" name="name" value=""/>
-      <Option name="properties"/>
-      <Option type="QString" name="type" value="collection"/>
-     </Option>
-    </data_defined_properties>
-   </layer>
-  </symbol>
-  <symbol force_rhr="0" clip_to_extent="1" is_animated="0" frame_rate="10" alpha="1" type="fill" name="fillSymbol">
-   <data_defined_properties>
-    <Option type="Map">
-     <Option type="QString" name="name" value=""/>
-     <Option name="properties"/>
-     <Option type="QString" name="type" value="collection"/>
-    </Option>
-   </data_defined_properties>
-   <layer class="SimpleFill" pass="0" locked="0" enabled="1">
-    <Option type="Map">
-     <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
-     <Option type="QString" name="color" value="255,255,255,255"/>
-     <Option type="QString" name="joinstyle" value="bevel"/>
-     <Option type="QString" name="offset" value="0,0"/>
-     <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
-     <Option type="QString" name="offset_unit" value="MM"/>
-     <Option type="QString" name="outline_color" value="128,128,128,255"/>
-     <Option type="QString" name="outline_style" value="no"/>
-     <Option type="QString" name="outline_width" value="0"/>
-     <Option type="QString" name="outline_width_unit" value="Point"/>
-     <Option type="QString" name="style" value="solid"/>
-    </Option>
-    <data_defined_properties>
-     <Option type="Map">
-      <Option type="QString" name="name" value=""/>
-      <Option name="properties"/>
-      <Option type="QString" name="type" value="collection"/>
-     </Option>
-    </data_defined_properties>
-   </layer>
-  </symbol>
- </background>
- <shadow shadowUnder="0" shadowScale="100" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowDraw="0" shadowOpacity="0.69999999999999996" shadowRadiusAlphaOnly="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowRadius="1.5" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowOffsetUnit="MM" shadowBlendMode="6"/>
- <dd_properties>
-  <Option type="Map">
-   <Option type="QString" name="name" value=""/>
-   <Option name="properties"/>
-   <Option type="QString" name="type" value="collection"/>
-  </Option>
- </dd_properties>
-</text-style>""",
+        '<text-style><text-buffer bufferColor="250,250,250,255" bufferJoinStyle="128" bufferSize="1" bufferDraw="1" bufferSizeUnits="MM" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferNoFill="1"/></text-style>',
     )
 
     # Add Image (QGreenland logo):

--- a/qgreenland/util/qgis/project.py
+++ b/qgreenland/util/qgis/project.py
@@ -275,6 +275,106 @@ def _add_decorations(project: qgc.QgsProject) -> None:
     project.writeEntry("CopyrightLabel", "/MarginH", 0)
     project.writeEntry("CopyrightLabel", "/MarginV", 0)
 
+    # TODO: can we figure out a way to export `text_format` to xml so that it
+    # can be written to the project file without hard-coding everything? The
+    # `text_format` (`QgsTextFormat`) object has a `writeXml` method but it is
+    # unclear how to apply it to the project file.
+
+    # text_format = qgc.QgsTextFormat()
+    # buffer_settings = text_format.buffer()
+    # buffer_settings.setEnabled(True)
+    # text_format.setBuffer(buffer_settings)
+
+    project.writeEntry(
+        "CopyrightLabel",
+        "/Font",
+        """<text-style multilineHeightUnit="Percentage" forcedItalic="0" namedStyle="Regular" forcedBold="0" capitalization="0" fontWeight="50" fontKerning="1" fontItalic="0" fontStrikeout="0" blendMode="0" fontWordSpacing="0" multilineHeight="1" fontSizeUnit="Point" textOrientation="horizontal" textColor="50,50,50,255" textOpacity="1" fontSize="10" fontSizeMapUnitScale="3x:0,0,0,0,0,0" previewBkgrdColor="255,255,255,255" allowHtml="0" fontFamily="Open Sans" fontLetterSpacing="0" fontUnderline="0">
+ <families/>
+ <text-buffer bufferColor="250,250,250,255" bufferJoinStyle="128" bufferSize="1" bufferDraw="1" bufferSizeUnits="MM" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferNoFill="1"/>
+ <text-mask maskEnabled="0" maskOpacity="1" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSize="0" maskSizeUnits="MM" maskedSymbolLayers="" maskJoinStyle="128"/>
+ <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="Point" shapeType="0" shapeDraw="0" shapeBlendMode="0" shapeSizeX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="Point" shapeOpacity="1" shapeRadiiX="0" shapeSizeType="0" shapeOffsetX="0" shapeRadiiUnit="Point" shapeRadiiY="0" shapeSVGFile="" shapeFillColor="255,255,255,255" shapeOffsetY="0" shapeOffsetUnit="Point" shapeRotationType="0" shapeRotation="0" shapeBorderColor="128,128,128,255" shapeJoinStyle="64" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidth="0">
+  <symbol force_rhr="0" clip_to_extent="1" is_animated="0" frame_rate="10" alpha="1" type="marker" name="markerSymbol">
+   <data_defined_properties>
+    <Option type="Map">
+     <Option type="QString" name="name" value=""/>
+     <Option name="properties"/>
+     <Option type="QString" name="type" value="collection"/>
+    </Option>
+   </data_defined_properties>
+   <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
+    <Option type="Map">
+     <Option type="QString" name="angle" value="0"/>
+     <Option type="QString" name="cap_style" value="square"/>
+     <Option type="QString" name="color" value="190,178,151,255"/>
+     <Option type="QString" name="horizontal_anchor_point" value="1"/>
+     <Option type="QString" name="joinstyle" value="bevel"/>
+     <Option type="QString" name="name" value="circle"/>
+     <Option type="QString" name="offset" value="0,0"/>
+     <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+     <Option type="QString" name="offset_unit" value="MM"/>
+     <Option type="QString" name="outline_color" value="35,35,35,255"/>
+     <Option type="QString" name="outline_style" value="solid"/>
+     <Option type="QString" name="outline_width" value="0"/>
+     <Option type="QString" name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+     <Option type="QString" name="outline_width_unit" value="MM"/>
+     <Option type="QString" name="scale_method" value="diameter"/>
+     <Option type="QString" name="size" value="2"/>
+     <Option type="QString" name="size_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+     <Option type="QString" name="size_unit" value="MM"/>
+     <Option type="QString" name="vertical_anchor_point" value="1"/>
+    </Option>
+    <data_defined_properties>
+     <Option type="Map">
+      <Option type="QString" name="name" value=""/>
+      <Option name="properties"/>
+      <Option type="QString" name="type" value="collection"/>
+     </Option>
+    </data_defined_properties>
+   </layer>
+  </symbol>
+  <symbol force_rhr="0" clip_to_extent="1" is_animated="0" frame_rate="10" alpha="1" type="fill" name="fillSymbol">
+   <data_defined_properties>
+    <Option type="Map">
+     <Option type="QString" name="name" value=""/>
+     <Option name="properties"/>
+     <Option type="QString" name="type" value="collection"/>
+    </Option>
+   </data_defined_properties>
+   <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+    <Option type="Map">
+     <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+     <Option type="QString" name="color" value="255,255,255,255"/>
+     <Option type="QString" name="joinstyle" value="bevel"/>
+     <Option type="QString" name="offset" value="0,0"/>
+     <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+     <Option type="QString" name="offset_unit" value="MM"/>
+     <Option type="QString" name="outline_color" value="128,128,128,255"/>
+     <Option type="QString" name="outline_style" value="no"/>
+     <Option type="QString" name="outline_width" value="0"/>
+     <Option type="QString" name="outline_width_unit" value="Point"/>
+     <Option type="QString" name="style" value="solid"/>
+    </Option>
+    <data_defined_properties>
+     <Option type="Map">
+      <Option type="QString" name="name" value=""/>
+      <Option name="properties"/>
+      <Option type="QString" name="type" value="collection"/>
+     </Option>
+    </data_defined_properties>
+   </layer>
+  </symbol>
+ </background>
+ <shadow shadowUnder="0" shadowScale="100" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowDraw="0" shadowOpacity="0.69999999999999996" shadowRadiusAlphaOnly="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowRadius="1.5" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowOffsetUnit="MM" shadowBlendMode="6"/>
+ <dd_properties>
+  <Option type="Map">
+   <Option type="QString" name="name" value=""/>
+   <Option name="properties"/>
+   <Option type="QString" name="type" value="collection"/>
+  </Option>
+ </dd_properties>
+</text-style>""",
+    )
+
     # Add Image (QGreenland logo):
     project.writeEntry("Image", "/Enabled", True)
     project.writeEntry("Image", "/Placement", 0)

--- a/qgreenland/util/qgis/project.py
+++ b/qgreenland/util/qgis/project.py
@@ -275,19 +275,27 @@ def _add_decorations(project: qgc.QgsProject) -> None:
     project.writeEntry("CopyrightLabel", "/MarginH", 0)
     project.writeEntry("CopyrightLabel", "/MarginV", 0)
 
+    # Add buffer around copyright text
     # TODO: can we figure out a way to export `text_format` to xml so that it
     # can be written to the project file without hard-coding everything? The
     # `text_format` (`QgsTextFormat`) object has a `writeXml` method but it is
-    # unclear how to apply it to the project file.
-
+    # unclear how to apply it to the project file:
+    # ```
     # text_format = qgc.QgsTextFormat()
     # buffer_settings = text_format.buffer()
     # buffer_settings.setEnabled(True)
     # text_format.setBuffer(buffer_settings)
+    # text_format.write_xml(...)
+    # ```
     project.writeEntry(
         "CopyrightLabel",
         "/Font",
-        '<text-style><text-buffer bufferColor="250,250,250,255" bufferJoinStyle="128" bufferSize="1" bufferDraw="1" bufferSizeUnits="MM" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferNoFill="1"/></text-style>',
+        (
+            '<text-style><text-buffer bufferColor="250,250,250,255"'
+            ' bufferJoinStyle="128" bufferSize="1" bufferDraw="1"'
+            ' bufferSizeUnits="MM" bufferOpacity="1" bufferBlendMode="0"'
+            ' bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferNoFill="1"/></text-style>'
+        ),
     )
 
     # Add Image (QGreenland logo):


### PR DESCRIPTION
## Description

Buffer the copyright text in the lower-right hand corner. Closes #652 

Uses the default buffer, which we commonly use for labeled vector features.

## Checklist

If an item on this list is done _or not needed_, check it with `[x]` or click the
checkbox.

- [x] The PR description links to issues that it resolves with `closes #{issue_number}`
- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Environment lockfile updated if needed (`conda-lock`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build)`)
- [x] CHANGELOG.md updated
- [x] Documentation updated if needed
- [x] New unit tests if needed
