### PR TITLE
Update arctic_vegetation style to show raster values in label

### DIFF
--- a/qgreenland/ancillary/styles/arctic_vegetation.qml
+++ b/qgreenland/ancillary/styles/arctic_vegetation.qml
@@ -1,102 +1,102 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis hasScaleBasedVisibilityFlag="0" version="3.28.7-Firenze" maxScale="0" minScale="1e+08" styleCategories="AllStyleCategories">
+<qgis maxScale="0" minScale="1e+08" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" version="3.28.8-Firenze">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <temporal fetchMode="0" mode="0" enabled="0">
+  <temporal mode="0" enabled="0" fetchMode="0">
     <fixedRange>
       <start></start>
       <end></end>
     </fixedRange>
   </temporal>
-  <elevation symbology="Line" zoffset="0" band="1" enabled="0" zscale="1">
+  <elevation zscale="1" symbology="Line" zoffset="0" band="1" enabled="0">
     <data-defined-properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option name="type" type="QString" value="collection"/>
       </Option>
     </data-defined-properties>
     <profileLineSymbol>
-      <symbol alpha="1" frame_rate="10" is_animated="0" type="line" clip_to_extent="1" force_rhr="0" name="">
+      <symbol name="" type="line" alpha="1" force_rhr="0" is_animated="0" frame_rate="10" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleLine" locked="0" enabled="1">
+        <layer locked="0" pass="0" class="SimpleLine" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="0" name="align_dash_pattern"/>
-            <Option type="QString" value="square" name="capstyle"/>
-            <Option type="QString" value="5;2" name="customdash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-            <Option type="QString" value="MM" name="customdash_unit"/>
-            <Option type="QString" value="0" name="dash_pattern_offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-            <Option type="QString" value="0" name="draw_inside_polygon"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="114,155,111,255" name="line_color"/>
-            <Option type="QString" value="solid" name="line_style"/>
-            <Option type="QString" value="0.6" name="line_width"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="0" name="trim_distance_end"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-            <Option type="QString" value="0" name="trim_distance_start"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-            <Option type="QString" value="0" name="use_custom_dash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+            <Option name="align_dash_pattern" type="QString" value="0"/>
+            <Option name="capstyle" type="QString" value="square"/>
+            <Option name="customdash" type="QString" value="5;2"/>
+            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="customdash_unit" type="QString" value="MM"/>
+            <Option name="dash_pattern_offset" type="QString" value="0"/>
+            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+            <Option name="draw_inside_polygon" type="QString" value="0"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="line_color" type="QString" value="114,155,111,255"/>
+            <Option name="line_style" type="QString" value="solid"/>
+            <Option name="line_width" type="QString" value="0.6"/>
+            <Option name="line_width_unit" type="QString" value="MM"/>
+            <Option name="offset" type="QString" value="0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="ring_filter" type="QString" value="0"/>
+            <Option name="trim_distance_end" type="QString" value="0"/>
+            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+            <Option name="trim_distance_start" type="QString" value="0"/>
+            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+            <Option name="use_custom_dash" type="QString" value="0"/>
+            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </profileLineSymbol>
     <profileFillSymbol>
-      <symbol alpha="1" frame_rate="10" is_animated="0" type="fill" clip_to_extent="1" force_rhr="0" name="">
+      <symbol name="" type="fill" alpha="1" force_rhr="0" is_animated="0" frame_rate="10" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
+        <layer locked="0" pass="0" class="SimpleFill" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="114,155,111,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,255" name="outline_color"/>
-            <Option type="QString" value="no" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="114,155,111,255"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_style" type="QString" value="no"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -105,24 +105,24 @@
   </elevation>
   <customproperties>
     <Option type="Map">
-      <Option type="bool" value="false" name="WMSBackgroundLayer"/>
-      <Option type="bool" value="false" name="WMSPublishDataSourceUrl"/>
-      <Option type="int" value="0" name="embeddedWidgets/count"/>
-      <Option type="QString" value="Value" name="identify/format"/>
+      <Option name="WMSBackgroundLayer" type="bool" value="false"/>
+      <Option name="WMSPublishDataSourceUrl" type="bool" value="false"/>
+      <Option name="embeddedWidgets/count" type="int" value="0"/>
+      <Option name="identify/format" type="QString" value="Value"/>
     </Option>
   </customproperties>
   <pipe-data-defined-properties>
     <Option type="Map">
-      <Option type="QString" value="" name="name"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option type="QString" value="collection" name="type"/>
+      <Option name="type" type="QString" value="collection"/>
     </Option>
   </pipe-data-defined-properties>
   <pipe>
     <provider>
-      <resampling zoomedInResamplingMethod="nearestNeighbour" zoomedOutResamplingMethod="nearestNeighbour" maxOversampling="2" enabled="false"/>
+      <resampling zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour" enabled="false" maxOversampling="2"/>
     </provider>
-    <rasterrenderer opacity="1" alphaBand="-1" type="paletted" band="1" nodataColor="">
+    <rasterrenderer alphaBand="-1" type="paletted" nodataColor="" band="1" opacity="1">
       <rasterTransparency/>
       <minMaxOrigin>
         <limits>None</limits>
@@ -133,41 +133,41 @@
         <stdDevFactor>2</stdDevFactor>
       </minMaxOrigin>
       <colorPalette>
-        <paletteEntry alpha="255" label="B1 - Cryptogam, herb barren" color="#cdcfa8" value="1"/>
-        <paletteEntry alpha="255" label="B2a - Cryptogam, barren complex" color="#939a33" value="2"/>
-        <paletteEntry alpha="255" label="B3 - Non-carbonate mountain complex" color="#896f70" value="3"/>
-        <paletteEntry alpha="255" label="B4 - Carbonate mountain complex" color="#706d8c" value="4"/>
-        <paletteEntry alpha="255" label="B2b - Cryptogam, barren, dwarf-shrub complex" color="#a9b259" value="5"/>
-        <paletteEntry alpha="255" label="G1 - Graminoid, forb, cryptogam tundra" color="#f5e8a2" value="21"/>
-        <paletteEntry alpha="255" label="G2 - Graminoid, prostrate dwarf-shrub, forb, moss tundra" color="#eccc75" value="22"/>
-        <paletteEntry alpha="255" label="G3 - Non-tussock sedge, dwarf-shrub, moss tundra" color="#c6b62f" value="23"/>
-        <paletteEntry alpha="255" label="G4 - Tussock-sedge, dwarf-shrub, moss tundra" color="#ecec32" value="24"/>
-        <paletteEntry alpha="255" label="P1 - Prostrate dwarf-shrub, herb, lichen tundra" color="#c5a1a1" value="31"/>
-        <paletteEntry alpha="255" label="P2 - Prostrate/hemi-prostrate dwarf-shrub, lichen tundra" color="#ba828d" value="32"/>
-        <paletteEntry alpha="255" label="S1 - Erect dwarf-shrub, moss tundra" color="#9ac339" value="33"/>
-        <paletteEntry alpha="255" label="S2 - Low-shrub, moss tundra" color="#599a3e" value="34"/>
-        <paletteEntry alpha="255" label="W1 - Sedge/grass, moss wetland complex" color="#aacea8" value="41"/>
-        <paletteEntry alpha="255" label="W2 - Sedge, moss, dwarf-shrub wetland complex" color="#9ac8bd" value="42"/>
-        <paletteEntry alpha="255" label="W3 - Sedge, moss, low-shrub wetland complex" color="#74b289" value="43"/>
-        <paletteEntry alpha="255" label="FW - Fresh water" color="#4656a3" value="91"/>
-        <paletteEntry alpha="255" label="SW - Saline water" color="#bbc4e5" value="92"/>
-        <paletteEntry alpha="255" label="GL - Glacier" color="#ffffff" value="93"/>
-        <paletteEntry alpha="255" label="NA - Non-Arctic" color="#f6e9b5" value="99"/>
+        <paletteEntry color="#cdcfa8" alpha="255" label="1: B1 - Cryptogam, herb barren" value="1"/>
+        <paletteEntry color="#939a33" alpha="255" label="2: B2a - Cryptogam, barren complex" value="2"/>
+        <paletteEntry color="#896f70" alpha="255" label="3: B3 - Non-carbonate mountain complex" value="3"/>
+        <paletteEntry color="#706d8c" alpha="255" label="4: B4 - Carbonate mountain complex" value="4"/>
+        <paletteEntry color="#a9b259" alpha="255" label="5: B2b - Cryptogam, barren, dwarf-shrub complex" value="5"/>
+        <paletteEntry color="#f5e8a2" alpha="255" label="21: G1 - Graminoid, forb, cryptogam tundra" value="21"/>
+        <paletteEntry color="#eccc75" alpha="255" label="22: G2 - Graminoid, prostrate dwarf-shrub, forb, moss tundra" value="22"/>
+        <paletteEntry color="#c6b62f" alpha="255" label="23: G3 - Non-tussock sedge, dwarf-shrub, moss tundra" value="23"/>
+        <paletteEntry color="#ecec32" alpha="255" label="24: G4 - Tussock-sedge, dwarf-shrub, moss tundra" value="24"/>
+        <paletteEntry color="#c5a1a1" alpha="255" label="31: P1 - Prostrate dwarf-shrub, herb, lichen tundra" value="31"/>
+        <paletteEntry color="#ba828d" alpha="255" label="32: P2 - Prostrate/hemi-prostrate dwarf-shrub, lichen tundra" value="32"/>
+        <paletteEntry color="#9ac339" alpha="255" label="33: S1 - Erect dwarf-shrub, moss tundra" value="33"/>
+        <paletteEntry color="#599a3e" alpha="255" label="34: S2 - Low-shrub, moss tundra" value="34"/>
+        <paletteEntry color="#aacea8" alpha="255" label="41: W1 - Sedge/grass, moss wetland complex" value="41"/>
+        <paletteEntry color="#9ac8bd" alpha="255" label="42: W2 - Sedge, moss, dwarf-shrub wetland complex" value="42"/>
+        <paletteEntry color="#74b289" alpha="255" label="43: W3 - Sedge, moss, low-shrub wetland complex" value="43"/>
+        <paletteEntry color="#4656a3" alpha="255" label="91: FW - Fresh water" value="91"/>
+        <paletteEntry color="#bbc4e5" alpha="255" label="92: SW - Saline water" value="92"/>
+        <paletteEntry color="#ffffff" alpha="255" label="93: GL - Glacier" value="93"/>
+        <paletteEntry color="#f6e9b5" alpha="255" label="99: NA - Non-Arctic" value="99"/>
       </colorPalette>
-      <colorramp type="gradient" name="[source]">
+      <colorramp name="[source]" type="gradient">
         <Option type="Map">
-          <Option type="QString" value="215,25,28,255" name="color1"/>
-          <Option type="QString" value="43,131,186,255" name="color2"/>
-          <Option type="QString" value="ccw" name="direction"/>
-          <Option type="QString" value="0" name="discrete"/>
-          <Option type="QString" value="gradient" name="rampType"/>
-          <Option type="QString" value="rgb" name="spec"/>
-          <Option type="QString" value="0.25;253,174,97,255;rgb;ccw:0.5;255,255,191,255;rgb;ccw:0.75;171,221,164,255;rgb;ccw" name="stops"/>
+          <Option name="color1" type="QString" value="215,25,28,255"/>
+          <Option name="color2" type="QString" value="43,131,186,255"/>
+          <Option name="direction" type="QString" value="ccw"/>
+          <Option name="discrete" type="QString" value="0"/>
+          <Option name="rampType" type="QString" value="gradient"/>
+          <Option name="spec" type="QString" value="rgb"/>
+          <Option name="stops" type="QString" value="0.25;253,174,97,255;rgb;ccw:0.5;255,255,191,255;rgb;ccw:0.75;171,221,164,255;rgb;ccw"/>
         </Option>
       </colorramp>
     </rasterrenderer>
-    <brightnesscontrast contrast="0" gamma="1" brightness="0"/>
-    <huesaturation colorizeOn="0" colorizeStrength="100" saturation="0" colorizeBlue="128" colorizeGreen="128" invertColors="0" colorizeRed="255" grayscaleMode="0"/>
+    <brightnesscontrast contrast="0" brightness="0" gamma="1"/>
+    <huesaturation colorizeGreen="128" colorizeRed="255" grayscaleMode="0" colorizeStrength="100" invertColors="0" colorizeOn="0" colorizeBlue="128" saturation="0"/>
     <rasterresampler maxOversampling="2"/>
     <resamplingStage>resamplingFilter</resamplingStage>
   </pipe>


### PR DESCRIPTION
## Description

Closes #778 

Updates the vegetation legend to show raster value in each label. E.g., `B1 - Cryptogam, herb barren` to `1: B1 - Cryptogam, herb barren`

![updated-labels](https://github.com/nsidc/qgreenland/assets/19692879/0318ae3b-3c48-43a3-85be-cf22fde35332)


## Checklist

If an item on this list is done _or not needed_, check it with `[x]` or click the
checkbox.

- [x] The PR description links to issues that it resolves with `closes #{issue_number}`
- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Environment lockfile updated if needed (`conda-lock`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build)`)
- [x] CHANGELOG.md updated (for user-facing changes)
- [x] Documentation updated if needed
- [x] New unit tests if needed
