### PR TITLE
Add "addons" index to ref index listing

### DIFF
--- a/doc/user/reference/index.rst
+++ b/doc/user/reference/index.rst
@@ -15,11 +15,4 @@ Reference
     :glob:
 
     ./*
-
-
-.. toctree::
-    :name: Add-ons
-    :caption: Add-ons
-    :hidden:
-
-    addons/index
+    ./addons/index


### PR DESCRIPTION
## Description

Fixup issue with "addons" not showing up on the user ref index page.


## Checklist

If an item on this list is done _or not needed_, check it with `[x]` or click the
checkbox.

- [x] The PR description links to issues that it resolves with `closes #{issue_number}`
- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Environment lockfile updated if needed (`conda-lock`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build)`)
- [x] CHANGELOG.md updated (for user-facing changes)
- [x] Documentation updated if needed
- [x] New unit tests if needed
