### PR TITLE
Init dataset/layer config for seal tag data pulled from ADC

### DIFF
--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -1816,6 +1816,26 @@
         "title": "Sea Ice Index, Version 3"
       }
     },
+    "seal_tag_measurements": {
+      "assets": {
+        "only": {
+          "id": "only",
+          "urls": [
+            "https://arcticdata.io/metacat/d1/mn/v2/object/urn%3Auuid%3A31162eb9-7e3b-4b88-948f-f4c99f13a83f"
+          ],
+          "verify_tls": true
+        }
+      },
+      "id": "seal_tag_measurements",
+      "metadata": {
+        "abstract": "This project involves a marine-mammal sensor-tagging\napproach that will allow for sustained oceanographic observations along\nthe periphery of the Greenland Ice Sheet. This effort is motivated by a\nsuccessful pilot project involving ringed seals in two Greenland fjords\nthis past summer. The pilot proved the viability of the technique, which\nmakes use of ringed seals who spend the majority of their time in such\nfjords and who may be appropriately equipped with integrated,\nlocation-tracking, CTD, and satellite communication instrumentation. The\nobservations, which will be collected in partnership with colleagues at\nthe Greenland Institute of Natural Resources, will be archived in\nnational data bases, on a project website, and made widely available to\nothers in near real-time. This project will address a currently missing,\ncritical component of the Arctic Observing Network, namely observations\nof ocean temperatures and salinities along the periphery of the\nGreenland Ice Sheet. The methodology will lead to a practical,\nsustainable data stream for hydrographic properties in the notoriously\ndifficult to access regions of the Greenland inner fjords, thus further\nfilling out the overall Arctic Observing Network data portfolio. Such\nobservations are needed to develop improved physics that can\nsubsequently be directly used in IPCC class, coupled climate models. The\ndata collection will also be of immense value to researchers studying\nthe behavior of the ringed seals in Greenland. Virtually no behavioral\ndata exists for these seals in the ice-ocean fjords, and the project\ndata can be used to learn about the habitat and distribution of the\nseals, and ultimately of their possible vulnerability to climate\nchange.",
+        "citation": {
+          "text": "David Holland. (2018). Water temperature, salinity, and\nposition-geographic data taken from seal tags, in coastal Greenland\nfrom 2010-08-31 to 2012-05-14. Arctic Data\nCenter. urn:uuid:1f3f702f-9594-4293-8cbd-07932e54e8ed.",
+          "url": "https://arcticdata.io/catalog/view/urn%3Auuid%3A1f3f702f-9594-4293-8cbd-07932e54e8ed"
+        },
+        "title": "Water temperature, salinity, and position-geographic data taken from seal tags, in coastal Greenland from 2010-08-31 to 2012-05-14"
+      }
+    },
     "seismograph_stations": {
       "assets": {
         "only": {
@@ -24771,6 +24791,49 @@
       {
         "children": [
           {
+            "layer_cfg": {
+              "description": "Locaitons of seal tag measurements with temperature and salinity in coastal Greenland from 2010-08-31 to 2012-05-14.",
+              "id": "seal_tag_measurements",
+              "in_package": true,
+              "input": {
+                "asset": {
+                  "id": "only"
+                },
+                "dataset": {
+                  "id": "seal_tag_measurements"
+                }
+              },
+              "show": false,
+              "steps": [
+                {
+                  "args": [
+                    "ogr2ogr",
+                    "-lco",
+                    "ENCODING=UTF-8",
+                    "-t_srs",
+                    "EPSG:3413",
+                    "-clipdst",
+                    "{assets_dir}/latitude_shape_40_degrees.geojson",
+                    "-makevalid",
+                    "-s_srs",
+                    "EPSG:4326",
+                    "-oo",
+                    "X_POSSIBLE_NAMES=Longitude",
+                    "-oo",
+                    "Y_POSSIBLE_NAMES=Latitude",
+                    "{output_dir}/final.gpkg",
+                    "{input_dir}/*.csv"
+                  ],
+                  "type": "command"
+                }
+              ],
+              "style": null,
+              "tags": [],
+              "title": "Seal tag water measurements"
+            },
+            "name": "seal_tag_measurements"
+          },
+          {
             "children": [
               {
                 "layer_cfg": {
@@ -26615,6 +26678,7 @@
         "settings": {
           "expand": false,
           "order": [
+            ":seal_tag_measurements",
             "Undersea feature names",
             "Seawater temperature (25km)",
             "Seawater salinity (25km)",

--- a/qgreenland/config/datasets/seal_tag_water_measurements.py
+++ b/qgreenland/config/datasets/seal_tag_water_measurements.py
@@ -1,0 +1,54 @@
+from qgreenland.models.config.asset import HttpAsset
+from qgreenland.models.config.dataset import Dataset
+
+dataset = Dataset(
+    id="seal_tag_measurements",
+    assets=[
+        HttpAsset(
+            id="only",
+            urls=[
+                "https://arcticdata.io/metacat/d1/mn/v2/object/urn%3Auuid%3A31162eb9-7e3b-4b88-948f-f4c99f13a83f",
+            ],
+        ),
+    ],
+    metadata={
+        "title": "Water temperature, salinity, and position-geographic data taken from seal tags, in coastal Greenland from 2010-08-31 to 2012-05-14",
+        "abstract": (
+            """This project involves a marine-mammal sensor-tagging
+        approach that will allow for sustained oceanographic observations along
+        the periphery of the Greenland Ice Sheet. This effort is motivated by a
+        successful pilot project involving ringed seals in two Greenland fjords
+        this past summer. The pilot proved the viability of the technique, which
+        makes use of ringed seals who spend the majority of their time in such
+        fjords and who may be appropriately equipped with integrated,
+        location-tracking, CTD, and satellite communication instrumentation. The
+        observations, which will be collected in partnership with colleagues at
+        the Greenland Institute of Natural Resources, will be archived in
+        national data bases, on a project website, and made widely available to
+        others in near real-time. This project will address a currently missing,
+        critical component of the Arctic Observing Network, namely observations
+        of ocean temperatures and salinities along the periphery of the
+        Greenland Ice Sheet. The methodology will lead to a practical,
+        sustainable data stream for hydrographic properties in the notoriously
+        difficult to access regions of the Greenland inner fjords, thus further
+        filling out the overall Arctic Observing Network data portfolio. Such
+        observations are needed to develop improved physics that can
+        subsequently be directly used in IPCC class, coupled climate models. The
+        data collection will also be of immense value to researchers studying
+        the behavior of the ringed seals in Greenland. Virtually no behavioral
+        data exists for these seals in the ice-ocean fjords, and the project
+        data can be used to learn about the habitat and distribution of the
+        seals, and ultimately of their possible vulnerability to climate
+        change."""
+        ),
+        "citation": {
+            "text": (
+                """David Holland. (2018). Water temperature, salinity, and
+            position-geographic data taken from seal tags, in coastal Greenland
+            from 2010-08-31 to 2012-05-14. Arctic Data
+            Center. urn:uuid:1f3f702f-9594-4293-8cbd-07932e54e8ed."""
+            ),
+            "url": "https://arcticdata.io/catalog/view/urn%3Auuid%3A1f3f702f-9594-4293-8cbd-07932e54e8ed",
+        },
+    },
+)

--- a/qgreenland/config/layers/Oceanography/__settings__.py
+++ b/qgreenland/config/layers/Oceanography/__settings__.py
@@ -1,10 +1,12 @@
 from qgreenland.models.config.layer_group import (
     LayerGroupIdentifier,
     LayerGroupSettings,
+    LayerIdentifier,
 )
 
 settings = LayerGroupSettings(
     order=[
+        LayerIdentifier("seal_tag_measurements"),
         LayerGroupIdentifier("Undersea feature names"),
         LayerGroupIdentifier("Seawater temperature (25km)"),
         LayerGroupIdentifier("Seawater salinity (25km)"),

--- a/qgreenland/config/layers/Oceanography/seal_tag_measurements.py
+++ b/qgreenland/config/layers/Oceanography/seal_tag_measurements.py
@@ -1,0 +1,31 @@
+from qgreenland.config.datasets.seal_tag_water_measurements import dataset
+from qgreenland.config.helpers.steps.ogr2ogr import ogr2ogr
+from qgreenland.models.config.layer import Layer, LayerInput
+
+layer = Layer(
+    id="seal_tag_measurements",
+    title="Seal tag water measurements",
+    description=(
+        """Locaitons of seal tag measurements with temperature and salinity in coastal Greenland from 2010-08-31 to 2012-05-14."""
+    ),
+    tags=[],
+    in_package=True,
+    input=LayerInput(
+        dataset=dataset,
+        asset=dataset.assets["only"],
+    ),
+    steps=[
+        *ogr2ogr(
+            input_file="{input_dir}/*.csv",
+            output_file="{output_dir}/final.gpkg",
+            ogr2ogr_args=(
+                "-s_srs",
+                "EPSG:4326",
+                "-oo",
+                "X_POSSIBLE_NAMES=Longitude",
+                "-oo",
+                "Y_POSSIBLE_NAMES=Latitude",
+            ),
+        ),
+    ],
+)


### PR DESCRIPTION
## Description

This PR adds a vector dataset giving the locations of seal tag measurements (water temp, salinity, depth, etc) from the ADC for demonstration purposes. This layer is relatively small and "easy" to transform into a QGreenland-ready dataset (csv w/ latitude and longitude columns -> Geopackage via `ogr2ogr`) and may be a good test-case for QGreenland-Net work.

Command to generate an (unzipped, `-Z` option) QGreenland package with the background layer and this new layer:

```
$ ./scripts/cli.sh run -Z --include="background" --include "seal_tag_measurements"

```

---

Note that there might be one issue with the dataset that isn't so "easy" to deal with: there appear to be rows that have no "Cruise", "Station", "Type", or "Date" values. These rows follow in chunks after rows that do have those values. I'm wondering if the values are "constant" until the next row w/ updated values for those attrs. E.g.,:

```
"Cruise","Station","Type","Date","Longitude","Latitude","depth_from_surface","Pressure","Temperature","Salinity","Fluorescence","Oxygen"
...
"ct71-01-10",1,"B","2010-08-31 12:00",-43.3587,60.0247,NA,40,-0.475,32.8837,999,999
"",NA,"","",NA,NA,NA,50,-0.6026,32.9236,999,999
"",NA,"","",NA,NA,NA,60,-0.6664,32.9769,999,999
"",NA,"","",NA,NA,NA,80,-0.743,33.1467,999,999
"",NA,"","",NA,NA,NA,100,-0.743,33.2,999,999
"",NA,"","",NA,NA,NA,113,-0.743,33.2,999,999
"ct71-01-10",2,"B","2010-08-31 17:00",-43.2995,60.0515,0,2,5.258,29.966,999,999
"",NA,"","",NA,NA,NA,10,5.1107,30.0879,999,999
"",NA,"","",NA,NA,NA,12,4.9477,30.1562,999,999
"",NA,"","",NA,NA,NA,14,4.8846,30.2049,999,999
"",NA,"","",NA,NA,NA,16,4.7479,30.3,999,999
...
```

If we end up wanting to actually include this data in QGreenland, we'll want to investigate more and fix if needed.

## Checklist

If an item on this list is done _or not needed_, check it with `[x]` or click the
checkbox.

- [ ] The PR description links to issues that it resolves with `closes #{issue_number}`
- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [ ] Environment lockfile updated if needed (`conda-lock`)
- [ ] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build)`)
- [ ] CHANGELOG.md updated (for user-facing changes)
- [ ] Documentation updated if needed
- [ ] New unit tests if needed
