### PR TITLE
PROMICE 2022 ice mask layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v4.0.0alpha3 (TODO)
+
+- Added layers:
+  - "Glaciology/PROMICE 2022 ice mask/"
+    - "Ice mask polygon"
+    - "Ice mask raster (150m)"
+
 # v4.0.0alpha2 (2025-03-13)
 
 - Minimum supported version of QGIS is now `v3.44`.

--- a/qgreenland/ancillary/styles/ice_mask_polygon.qml
+++ b/qgreenland/ancillary/styles/ice_mask_polygon.qml
@@ -1,0 +1,93 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.44.7-Solothurn" minScale="100000000" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" simplifyLocal="1" symbologyReferenceScale="-1" labelsEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1" maxScale="0" autoRefreshMode="Disabled" styleCategories="Symbology|Labeling|Rendering|Temporal" simplifyDrawingHints="1">
+  <temporal enabled="0" durationUnit="min" durationField="fid" fixedDuration="0" limitMode="0" mode="0" startField="" endField="" startExpression="" accumulate="0" endExpression="">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <renderer-v2 type="singleSymbol" referencescale="-1" forceraster="0" enableorderby="0" symbollevels="0">
+    <symbols>
+      <symbol force_rhr="0" clip_to_extent="1" type="fill" frame_rate="10" name="0" is_animated="0" alpha="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" locked="0" id="{dcf6727d-05e0-4024-b0f7-1302183f48df}" class="SimpleFill" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255,rgb:0.1372549,0.1372549,0.1372549,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.3" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </data-defined-properties>
+  </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol force_rhr="0" clip_to_extent="1" type="fill" frame_rate="10" name="" is_animated="0" alpha="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" locked="0" id="{b9cb2a5c-94a8-47b6-8138-c7820b3f0eb3}" class="SimpleFill" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,255,255,rgb:0,0,1,1" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255,rgb:0.1372549,0.1372549,0.1372549,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.26" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/qgreenland/config/cfg-lock.json
+++ b/qgreenland/config/cfg-lock.json
@@ -1506,6 +1506,33 @@
         "title": "Ground Temperature Map, 2000-2016, Northern Hemisphere Permafrost"
       }
     },
+    "promice_2022_ice_mask": {
+      "assets": {
+        "06_promice_2022_icemask_nunatak_polygon": {
+          "id": "06_promice_2022_icemask_nunatak_polygon",
+          "urls": [
+            "https://dataverse.geus.dk/api/access/datafile/96892?gbrecs=true"
+          ],
+          "verify_tls": true
+        },
+        "13_promice_2022_icemask_raster_150m_v3": {
+          "id": "13_promice_2022_icemask_raster_150m_v3",
+          "urls": [
+            "https://dataverse.geus.dk/api/access/datafile/97124?gbrecs=true"
+          ],
+          "verify_tls": true
+        }
+      },
+      "id": "promice_2022_ice_mask",
+      "metadata": {
+        "abstract": "The PROMICE-2022 Ice Mask is a high-resolution outline of the\ncontiguous ice masses of the Greenland Ice Sheet. The dataset is\nderived from a true-colour, multi-band mosaic of Sentinel-2\nsatellite images at 10 m resolution, compiled using the SentinelHub\nCloud Processing API. The mosaic was generated using the most recent\nvalid pixels from August 2022, ensuring high temporal and geometric\naccuracy.\n\nManual editing and mapping was conducted at a scale of around\n1:25,000, after which quality assessment was performed independently\nof the mapping operator, before finally being merged into one\ncoherent dataset. The manual mapping process is further supported by\ndata from the Danish Agency for Climate Data (KDS), including\nmosaics of Sentinel-2 and SPOT 6/7 imagery, as well as recent vector\ndata from topographical mapping.\n\nAssociated paper:\n\nLuetzenburg G. et al. (2026) PROMICE-2022 Ice Mask: A\nHigh-Resolution Outline of the Greenland Ice Sheet from August\n2022. Earth Syst. Sci. Data, 18,\n411\u2013427. https://doi.org/10.5194/essd-18-411-2026.",
+        "citation": {
+          "text": "Luetzenburg, Gregor; Korsgaard, Niels J.; Deichmann, Anna K.;\nSocher, Tobias; Gleie, Karin; Scharffenberger, Thomas; Fahrner,\nDominik; Nielsen, Eva B.; How, Penelope; Bj\u00f8rk, Anders A.;\nKjeldsen, Kristian K.; Ahlstr\u00f8m, Andreas P.; Fausto, Robert S.,\n2025, \"PROMICE-2022 Ice Mask\",\nhttps://doi.org/10.22008/FK2/O8CLRE, GEUS Dataverse, V3",
+          "url": "https://doi.org/10.22008/FK2/O8CLRE"
+        },
+        "title": "PROMICE-2022 Ice Mask"
+      }
+    },
     "promice_runoff": {
       "assets": {
         "land_mar_2010": {
@@ -14235,6 +14262,73 @@
               "title": "Likely basal thermal state June 23 1993 - April 26 2013 (5km)"
             },
             "name": "basal_thermal_state"
+          },
+          {
+            "children": [
+              {
+                "layer_cfg": {
+                  "description": "Outline of the Greenland Ice Sheet from August 2022 with the nunataks\nin its interior cut out, provided as a polygon vector feature.",
+                  "id": "06_promice_2022_icemask_nunatak_polygon",
+                  "in_package": true,
+                  "inputs": [
+                    {
+                      "asset": {
+                        "id": "06_promice_2022_icemask_nunatak_polygon"
+                      },
+                      "dataset": {
+                        "id": "promice_2022_ice_mask"
+                      }
+                    }
+                  ],
+                  "show": false,
+                  "steps": [],
+                  "style": "ice_mask_polygon",
+                  "tags": [],
+                  "title": "Ice mask polygon"
+                },
+                "name": "06_promice_2022_icemask_nunatak_polygon"
+              },
+              {
+                "layer_cfg": {
+                  "description": "Raster ice mask (150m resolution) aligned with BedMachine (Morlighem 2017).",
+                  "id": "13_promice_2022_icemask_raster_150m_v3",
+                  "in_package": true,
+                  "inputs": [
+                    {
+                      "asset": {
+                        "id": "13_promice_2022_icemask_raster_150m_v3"
+                      },
+                      "dataset": {
+                        "id": "promice_2022_ice_mask"
+                      }
+                    }
+                  ],
+                  "show": false,
+                  "steps": [
+                    {
+                      "args": [
+                        "gdalwarp",
+                        "-co",
+                        "COMPRESS=DEFLATE",
+                        "{input_dir}/*.gpkg",
+                        "{output_dir}/converted_and_compressed.tif"
+                      ],
+                      "type": "command"
+                    }
+                  ],
+                  "style": null,
+                  "tags": [],
+                  "title": "Ice mask raster (150m)"
+                },
+                "name": "13_promice_2022_icemask_raster_150m_v3"
+              }
+            ],
+            "name": "PROMICE 2022 ice mask",
+            "settings": {
+              "expand": false,
+              "order": null,
+              "show": false
+            }
           }
         ],
         "name": "Glaciology",
@@ -14251,7 +14345,8 @@
             "Surface elevation change",
             "Gravimetric mass balance",
             "Ice sheet velocity",
-            ":basal_thermal_state"
+            ":basal_thermal_state",
+            "PROMICE 2022 ice mask"
           ],
           "show": false
         }

--- a/qgreenland/config/datasets/promice_ice_mask.py
+++ b/qgreenland/config/datasets/promice_ice_mask.py
@@ -1,0 +1,55 @@
+from qgreenland.models.config.asset import HttpAsset
+from qgreenland.models.config.dataset import Dataset
+
+# The name of the `dataset` variable doesn't matter here.
+dataset = Dataset(
+    id="promice_2022_ice_mask",
+    assets=[
+        HttpAsset(
+            id="06_promice_2022_icemask_nunatak_polygon",
+            urls=["https://dataverse.geus.dk/api/access/datafile/96892?gbrecs=true"],
+        ),
+        HttpAsset(
+            id="13_promice_2022_icemask_raster_150m_v3",
+            urls=["https://dataverse.geus.dk/api/access/datafile/97124?gbrecs=true"],
+        ),
+    ],
+    metadata={
+        "title": "PROMICE-2022 Ice Mask",
+        "abstract": (
+            """The PROMICE-2022 Ice Mask is a high-resolution outline of the
+            contiguous ice masses of the Greenland Ice Sheet. The dataset is
+            derived from a true-colour, multi-band mosaic of Sentinel-2
+            satellite images at 10 m resolution, compiled using the SentinelHub
+            Cloud Processing API. The mosaic was generated using the most recent
+            valid pixels from August 2022, ensuring high temporal and geometric
+            accuracy.
+
+            Manual editing and mapping was conducted at a scale of around
+            1:25,000, after which quality assessment was performed independently
+            of the mapping operator, before finally being merged into one
+            coherent dataset. The manual mapping process is further supported by
+            data from the Danish Agency for Climate Data (KDS), including
+            mosaics of Sentinel-2 and SPOT 6/7 imagery, as well as recent vector
+            data from topographical mapping.
+
+            Associated paper:
+
+            Luetzenburg G. et al. (2026) PROMICE-2022 Ice Mask: A
+            High-Resolution Outline of the Greenland Ice Sheet from August
+            2022. Earth Syst. Sci. Data, 18,
+            411–427. https://doi.org/10.5194/essd-18-411-2026."""
+        ),
+        "citation": {
+            "text": (
+                """Luetzenburg, Gregor; Korsgaard, Niels J.; Deichmann, Anna K.;
+                Socher, Tobias; Gleie, Karin; Scharffenberger, Thomas; Fahrner,
+                Dominik; Nielsen, Eva B.; How, Penelope; Bjørk, Anders A.;
+                Kjeldsen, Kristian K.; Ahlstrøm, Andreas P.; Fausto, Robert S.,
+                2025, "PROMICE-2022 Ice Mask",
+                https://doi.org/10.22008/FK2/O8CLRE, GEUS Dataverse, V3"""
+            ),
+            "url": "https://doi.org/10.22008/FK2/O8CLRE",
+        },
+    },
+)

--- a/qgreenland/config/layers/Glaciology/PROMICE 2022 ice mask/promice_ice_mask.py
+++ b/qgreenland/config/layers/Glaciology/PROMICE 2022 ice mask/promice_ice_mask.py
@@ -1,0 +1,50 @@
+from qgreenland.config.datasets.promice_ice_mask import dataset as dataset
+from qgreenland.models.config.layer import Layer, LayerInput
+from qgreenland.models.config.step import CommandStep
+
+icemask_nunatak_polygon_layer = Layer(
+    id="06_promice_2022_icemask_nunatak_polygon",
+    title="Ice mask polygon",
+    description=(
+        """Outline of the Greenland Ice Sheet from August 2022 with the nunataks
+        in its interior cut out, provided as a polygon vector feature."""
+    ),
+    tags=[],
+    in_package=True,
+    style="ice_mask_polygon",
+    inputs=[
+        LayerInput(
+            dataset=dataset,
+            asset=dataset.assets["06_promice_2022_icemask_nunatak_polygon"],
+        )
+    ],
+    steps=[],
+)
+
+
+icemask_raster_150_layer = Layer(
+    id="13_promice_2022_icemask_raster_150m_v3",
+    title="Ice mask raster (150m)",
+    description=(
+        """Raster ice mask (150m resolution) aligned with BedMachine (Morlighem 2017)."""
+    ),
+    tags=[],
+    in_package=True,
+    inputs=[
+        LayerInput(
+            dataset=dataset,
+            asset=dataset.assets["13_promice_2022_icemask_raster_150m_v3"],
+        )
+    ],
+    steps=[
+        CommandStep(
+            args=[
+                "gdalwarp",
+                "-co",
+                "COMPRESS=DEFLATE",
+                "{input_dir}/*.gpkg",
+                "{output_dir}/converted_and_compressed.tif",
+            ],
+        )
+    ],
+)

--- a/qgreenland/config/layers/Glaciology/__settings__.py
+++ b/qgreenland/config/layers/Glaciology/__settings__.py
@@ -17,5 +17,6 @@ settings = LayerGroupSettings(
         LayerGroupIdentifier("Gravimetric mass balance"),
         LayerGroupIdentifier("Ice sheet velocity"),
         LayerIdentifier("basal_thermal_state"),
+        LayerGroupIdentifier("PROMICE 2022 ice mask"),
     ],
 )


### PR DESCRIPTION
## Description

Adds two new layers from the PROMICE 2022 ice mask layer:

- "Glaciology/PROMICE 2022 ice mask/"
  - "Ice mask polygon"
  - "Ice mask raster (150m)"

[The dataset](https://dataverse.geus.dk/dataset.xhtml?persistentId=doi:10.22008/FK2/O8CLRE) provides 15 products, each of which is suitable for different use cases. The two layers included here are from the `06-PROMICE-2022-IceMask-Nunatak-polygon-v3.gpkg` and `13-PROMICE-2022-IceMask-raster-150m-v3.gpkg`. I chose these two based on this from [the associated paper](https://essd.copernicus.org/articles/18/411/2026/):

> For most scientific and operational applications, we recommend two “master”
> datasets (Table 3). These two datasets represent the most complete, stable,
> and widely usable forms of the ice mask: (i) the polygon master dataset
> 06-PROMICE-2022-IceMask-Nunatak-polygon.gpkg is the best all-purpose polygon
> dataset representing the clean ice mask with nunataks removed and (ii) the
> raster master dataset 13-PROMICE-2022-IceMask-raster-150m.gpkg is optimized
> for modelling workflows that operate on gridded datasets aligned with
> BedMachine.

Happy to configure layers for other products if we would like any of them included. 

![PROMICE 2022 Ice Mask product guide](https://essd.copernicus.org/articles/18/411/2026/essd-18-411-2026-t03-web.png)

Resolves #849 

## Checklist

If an item on this list is done _or not needed_, check it with `[x]` or click the
checkbox.

- [x] The PR description links to issues that it resolves with `closes #{issue_number}`
- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Environment lockfile updated if needed (`conda-lock`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build)`)
- [x] CHANGELOG.md updated (for user-facing changes)
- [x] Documentation updated if needed
- [x] New unit tests if needed
