### PR TITLE
Set restart policy of webserver to "always"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,4 +61,4 @@ services:
       options:
         max-size: "20m"
         max-file: "5"
-    restart: "on-failure"
+    restart: "always"


### PR DESCRIPTION
## Description

Ensures that the service will come back after a VM reboot, which we expect to happen frequently as part of security updates applied by SAs at NSIDC.

Resolves https://github.com/nsidc/qgreenland-vm/issues/3

## Checklist

If an item on this list is done _or not needed_, check it with `[x]` or click the
checkbox.

- [x] The PR description links to issues that it resolves with `closes #{issue_number}`
- [x] Config lockfile updated (`inv config.export > qgreenland/config/cfg-lock.json`)
- [x] Environment lockfile updated if needed (`conda-lock`)
- [x] Version bumped if needed (`bumpversion (major|minor|patch|prerelease|build)`)
- [x] CHANGELOG.md updated (for user-facing changes)
- [x] Documentation updated if needed
- [x] New unit tests if needed
